### PR TITLE
Add RFC template

### DIFF
--- a/doc/design-docs/RFCS/00000000_template.md
+++ b/doc/design-docs/RFCS/00000000_template.md
@@ -1,0 +1,79 @@
+- Feature Name:
+- Status: draft/in-progress/completed/rejected/obsolete/postponed
+- Start Date: YYYY-MM-DD
+- Authors:
+- RFC PR: (PR # after acceptance of initial draft)
+- WeSQL-Scale  Issue: (one or more # from the issue tracker)
+
+# Summary
+
+One paragraph explanation of the proposed change.
+
+Suggested contents:
+- What is being proposed
+- Why (short reason)
+- How (short plan)
+- Impact
+
+# Motivation
+
+Why are we doing this? 
+What use cases does it support? 
+What is the expected outcome?
+
+
+# Technical design
+
+This is the technical portion of the RFC. Explain the design in sufficient detail.
+
+- Questions about the change:
+
+    - What components need to change? How do they change?
+
+    - Are there new abstractions introduced by the change? New concepts?
+      If yes, provide definitions and examples.
+      
+- Questions about performance:
+
+    - Does the change impact performance? How?
+    
+- Stability questions:
+
+    - Can this new functionality affect the stability of a node or the
+      entire cluster? 
+
+    - Can the new functionality be disabled? How?
+    
+    - What testing and safe guards are being put in place to
+      protect against unexpected problems?
+
+- Usage questions:
+
+    - Are there new APIs, or API changes (either internal or external)?
+
+
+## Drawbacks
+
+Why should we *not* do this?
+
+If applicable, list mitigating factors that may make each drawback acceptable.
+
+
+## Rationale and Alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+
+# Unresolved questions
+
+- What parts of the design do you expect to resolve through the RFC
+  process before this gets merged?
+
+- What parts of the design do you expect to resolve through the
+  implementation of this feature before stabilization?
+
+- What related issues do you consider out of scope for this RFC that
+  could be addressed in the future independently of the solution that
+  comes out of this RFC?


### PR DESCRIPTION
## Description

As we are about to start developing more new features and undertaking large-scale core functionality improvements for WeSQL-Scale, we require RFC documents as an communication and documentation tool.

Having a template will make our RFC document more focused and readable. I propose a RFC template and hope it will help us to enhance project transparency and reliability, and foster developer communication and collaboration.

The template is just a proposal; it is not mandatory. 
Modify the template if you think there's a better template form.