### PR TITLE
fix: support drop multiple tables/views in different db

### DIFF
--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -1,3 +1,8 @@
+/*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
 package planbuilder
 
 import (
@@ -333,18 +338,20 @@ func buildDropTable(vschema plancontext.VSchema, ddlStatement sqlparser.DDLState
 			}
 		} else {
 			keyspaceTab = table.Keyspace
-			ddlStatement.GetFromTables()[i] = sqlparser.TableName{
-				Name: table.Name,
-			}
+			// Regardless of how many tables are dropped, the database qualifier for each table must be retained.
+			//ddlStatement.GetFromTables()[i] = sqlparser.TableName{
+			//	Name: table.Name,
+			//}
 		}
 
 		if destination == nil && keyspace == nil {
 			destination = destinationTab
 			keyspace = keyspaceTab
 		}
-		if destination != destinationTab || keyspace != keyspaceTab {
-			return nil, nil, vterrors.VT12001(DifferentDestinations)
-		}
+		// When there are multiple databases, use the first database as the default database.
+		//if destination != destinationTab || keyspace != keyspaceTab {
+		//	return nil, nil, vterrors.VT12001(DifferentDestinations)
+		//}
 	}
 	return destination, keyspace, nil
 }


### PR DESCRIPTION
Currently, Vitess does not support dropping multiple tables or views from different databases in a single drop statement. Based on the foundation of unsharding and multi-database design of wesql-scale, the drop operation is modified as follows: when deleting multiple tables and views, the default database is the one identified by the first table or view, tables without a database prefix use this default database, and tables with a database prefix retain their database identifier.
fix #26 
fix #28 