### PR TITLE
chore: fix broken dashboard queries and add a new dev dashboard"

### DIFF
--- a/vitess-mixin/config.libsonnet
+++ b/vitess-mixin/config.libsonnet
@@ -36,6 +36,11 @@
         time_from: $._config.defaultTimeFrom,
       },
 
+      local devDashboard = {
+        environments: ['dev'],
+        time_from: $._config.defaultTimeFrom,
+      },
+
       // Overview
       clusterOverview+: defaultDashboard {
         uid: 'vitess-cluster-overview',
@@ -63,6 +68,15 @@
         description: 'Detailed vtgate view by host',
         dashboardTags: $._config.grafanaDashboardMetadataDefault.dashboardTags + ['vtgate', 'host'],
       },
+
+      // Dev View
+      devOverview+: devDashboard{
+        uid: 'vitess-overview-dev',
+        title: 'overview dev %(dashboardNameSuffix)s' % $._config.grafanaDashboardMetadataDefault,
+        description: 'cluster overview in development environment',
+        dashboardTags: $._config.grafanaDashboardMetadataDefault.dashboardTags + ['devview', 'cluster'],
+      },
+
     },
   },
 

--- a/vitess-mixin/dashboards/dashboards.libsonnet
+++ b/vitess-mixin/dashboards/dashboards.libsonnet
@@ -2,4 +2,5 @@
 (import 'layouts/vtgate_host_view.libsonnet') +
 (import 'layouts/vtgate_overview.libsonnet') +
 (import 'layouts/vttablet_host_view.libsonnet') +
+(import 'layouts/overview_dev.libsonnet') +
 (import 'defaults.libsonnet')

--- a/vitess-mixin/dashboards/layouts/overview_dev.libsonnet
+++ b/vitess-mixin/dashboards/layouts/overview_dev.libsonnet
@@ -1,0 +1,147 @@
+local helpers = import '../resources/grafonnet/helpers/helpers.libsonnet';
+local panels = import '../resources/grafonnet/panels.libsonnet';
+local rows = import '../resources/grafonnet/rows.libsonnet';
+local singlestats = import '../resources/grafonnet/singlestats.libsonnet';
+local templates = import '../resources/grafonnet/templates.libsonnet';
+local texts = import '../resources/grafonnet/texts.libsonnet';
+local heatmaps = import '../resources/grafonnet/heatmaps.libsonnet';
+
+local config = import '../../config.libsonnet';
+local rows_helper = helpers.default;
+
+{
+  grafanaDashboards+:: {
+    'overview_dev.json':
+      
+      helpers.dashboard.getDashboard(config._config.grafanaDashboardMetadata.devOverview)
+      .addTemplates([
+        templates.interval,
+        templates.hostVttablet,
+      ])
+      .addLink(helpers.default.getDashboardLink(config._config.dashborardLinks))
+      .addPanels([
+        # summary
+        rows.summary { gridPos: { h: 1, w: 24, x: 0, y: 0 } },
+        singlestats.vtgateSuccessRate { gridPos: { h: 4, w: 4, x: 0, y: 1 } },
+        singlestats.vttabletQuerySuccess { gridPos: { h: 4, w: 4, x: 4, y: 1 } },
+        helpers.vtgate.getSingleStat(config.vtgate.singlestats.vtgateQueryLatencyP99) { gridPos: { h: 4, w: 4, x: 8, y: 1 } },
+        helpers.vtgate.getSingleStat(config.vtgate.singlestats.vtgateQPS) { gridPos: { h: 2, w: 4, x: 12, y: 3 } },
+        helpers.vttablet.getSingleStat(config.vttablet.singlestats.vttabletQPS) { gridPos: { h: 2, w: 4, x: 12, y: 3 } },
+        singlestats.vtgateUp { gridPos: { h: 2, w: 2, x: 16, y: 1 } },
+        singlestats.vttabletUp { gridPos: { h: 2, w: 2, x: 16, y: 3 } },
+        singlestats.keyspaceCount { gridPos: { h: 2, w: 2, x: 18, y: 1 } },
+        singlestats.shardCount { gridPos: { h: 2, w: 2, x: 18, y: 3 } },
+
+        # hostview
+        # vtgate RED
+        rows.REDVtgate { gridPos: { h: 1, w: 24, x: 0, y: 7 } },
+        helpers.vtgate.getPanel(config.vtgate.panels.vtgateRequests) { gridPos: { h: 6, w: 8, x: 0, y: 8 } },
+        helpers.vtgate.getPanel(config.vtgate.panels.vtgateErrorRate) { gridPos: { h: 6, w: 8, x: 8, y: 8 } },
+        helpers.vtgate.getPanel(config.vtgate.panels.vtgateDurationP99) { gridPos: { h: 6, w: 8, x: 16, y: 8 } },
+
+        # vtgate RED by keyspace
+        rows.REDByKeyspace.addPanels([
+          helpers.vtgate.getPanel(config.vtgate.panels.vtgateRequestsByKeyspace) { gridPos: { h: 8, w: 8, x: 0, y: 15 } },
+          helpers.vtgate.getPanel(config.vtgate.panels.vtgateErrorRateByKeyspace) { gridPos: { h: 8, w: 8, x: 8, y: 15 } },
+          helpers.vtgate.getPanel(config.vtgate.panels.vtgateDurationP99ByKeyspace) { gridPos: { h: 8, w: 8, x: 16, y: 15 } },
+        ]){ gridPos: { h: 1, w: 24, x: 0, y: 14 } },
+
+        # vtgate RED by tablet type
+        rows.REDByTabletType.addPanels([
+          helpers.vtgate.getPanel(config.vtgate.panels.vtgateRequestsByDBType) { gridPos: { h: 7, w: 8, x: 0, y: 24 } },
+          helpers.vtgate.getPanel(config.vtgate.panels.vtgateErrorRateByDBType) { gridPos: { h: 7, w: 8, x: 8, y: 24 } },
+          helpers.vtgate.getPanel(config.vtgate.panels.vtgateDurationP99ByDBType) { gridPos: { h: 7, w: 8, x: 16, y: 24 } },
+        ]) { gridPos: { h: 1, w: 24, x: 0, y: 23 } },
+
+        # vttablet RED 
+        rows.REDTablet { gridPos: { h: 1, w: 24, x: 0, y: 31 } },
+        helpers.vttablet.getPanel(config.vttablet.panels.vttabletRequestsByInstance) { gridPos: { h: 7, w: 8, x: 0, y: 32 } },
+        helpers.vttablet.getPanel(config.vttablet.panels.vttabletErrorRateByInstance) { gridPos: { h: 7, w: 8, x: 8, y: 32 } },
+        helpers.vttablet.getPanel(config.vttablet.panels.vttabletQueryDurationP99ByInstance) { gridPos: { h: 7, w: 8, x: 16, y: 32 } },
+
+        # vttablet RED by plan type
+        rows.REDByPlanType.addPanels([
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletRequestsByPlanType) { gridPos: { h: 7, w: 8, x: 0, y: 40 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletErrorRateByPlanFilteredByInstance) { gridPos: { h: 7, w: 8, x: 8, y: 40 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletQueryDurationP99ByPlan) { gridPos: { h: 7, w: 8, x: 16, y: 40 } },
+        ]) { gridPos: { h: 1, w: 24, x: 0, y: 39 } },
+
+        # vttablet RED by table
+        rows.REDByTable.addPanels([
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletRequestsByTableFilteredByInstance) { gridPos: { h: 7, w: 8, x: 0, y: 50 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletErrorRateByTableFilteredByInstance) { gridPos: { h: 7, w: 8, x: 8, y: 50 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletQueryDurationP99ByTableFilteredByInstance) { gridPos: { h: 7, w: 8, x: 16, y: 50 } },
+        ]) { gridPos: { h: 1, w: 24, x: 0, y: 47 } },
+
+        # vtgate errors 
+        rows.errors.addPanels([
+          helpers.vtgate.getPanel(config.vtgate.panels.vtgateErrorsByCode) { gridPos: { h: 7, w: 8, x: 0, y: 58 } },
+          helpers.vtgate.getPanel(config.vtgate.panels.vtgateErrorsByOperation) { gridPos: { h: 7, w: 8, x: 8, y: 58 } },
+          helpers.vtgate.getPanel(config.vtgate.panels.vtgateErrorsByDbtype) { gridPos: { h: 7, w: 8, x: 16, y: 58 } },
+        ]) { gridPos: { h: 1, w: 24, x: 0, y: 57 } },
+
+        # vtgate duration
+        rows.duration.addPanels([
+          helpers.vtgate.getPanel(config.vtgate.panels.vtgateDurationAVG) { gridPos: { h: 7, w: 8, x: 0, y: 66 } },
+          helpers.vtgate.getPanel(config.vtgate.panels.vtgateDurationP50) { gridPos: { h: 7, w: 8, x: 8, y: 66 } },
+          helpers.vtgate.getPanel(config.vtgate.panels.vtgateDurationP95) { gridPos: { h: 7, w: 8, x: 16, y: 66 } },
+        ]) { gridPos: { h: 1, w: 24, x: 0, y: 65 } },
+
+        # vttablet row returned
+        rows.rowsReturned.addPanels([
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletRowsReturnedByTableFilteredByInstance) { gridPos: { h: 7, w: 12, x: 0, y: 74 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletRowsReturnedByPlansFilterByInstance) { gridPos: { h: 7, w: 12, x: 12, y: 74 } },
+        ]) { gridPos: { h: 1, w: 24, x: 0, y: 73 } },
+
+        # vttablet queries/errors
+        rows_helper.getRow(config.row.queryErrors).addPanels([
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletQueriesKilled) { gridPos: { h: 7, w: 8, x: 0, y: 82 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletQueryErrorsByType) { gridPos: { h: 7, w: 8, x: 8, y: 82 } },
+        ]) { gridPos: { h: 1, w: 24, x: 0, y: 81 } },
+
+        rows.vitessQueryPool.addPanels([
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletQueryPoolAvailableConnections) { gridPos: { h: 7, w: 8, x: 0, y: 90 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletQueryPoolActiveConnections) { gridPos: { h: 7, w: 8, x: 8, y: 90 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletQueryPoolIddleClosedRate) { gridPos: { h: 7, w: 8, x: 16, y: 90 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletQueryPoolWaitCount) { gridPos: { h: 7, w: 8, x: 0, y: 97 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletQueryPoolAvgWaitTime) { gridPos: { h: 7, w: 8, x: 8, y: 97 } },
+        ]) { gridPos: { h: 1, w: 24, x: 0, y: 89 } },
+
+        rows.vitessTransactionPool.addPanels([
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletTransactionPoolAvailableConnections) { gridPos: { h: 7, w: 8, x: 0, y: 105 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletTransactionPoolActiveConnections) { gridPos: { h: 7, w: 8, x: 8, y: 105 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletTransactionPoolIddleClosedRate) { gridPos: { h: 7, w: 8, x: 16, y: 105 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletTransactionPoolWaitCount) { gridPos: { h: 7, w: 8, x: 0, y: 112 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletTransactionPoolAvgWaitTime) { gridPos: { h: 7, w: 8, x: 8, y: 112 } },
+        ]) { gridPos: { h: 1, w: 24, x: 0, y: 104 } },
+
+        rows_helper.getRow(config.row.vitessTimings).addPanels([
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletTransactionDurationAvgByInstance) { gridPos: { h: 7, w: 8, x: 0, y: 120 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletTransactionDurationP50ByInstance) { gridPos: { h: 7, w: 8, x: 8, y: 120 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletTransactionDurationP95ByInstance) { gridPos: { h: 7, w: 8, x: 16, y: 120 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vtgateToVtTabletCallTimeAvgFilteredByInstance) { gridPos: { h: 7, w: 8, x: 0, y: 127 } },
+          heatmaps.vttabletQueryTimeDistribution { gridPos: { h: 7, w: 16, x: 8, y: 127 } },
+        ]) { gridPos: { h: 1, w: 24, x: 0, y: 119 } },
+
+        # TODO vttablet slow queries for dev env
+
+        rows_helper.getRow(config.row.mysqlTimings).addPanels([
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletMysqlTimeAvgFilteredByInstance) { gridPos: { h: 7, w: 8, x: 0, y: 142 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletMysqlExecTimeP50FilterebyInstance) { gridPos: { h: 7, w: 8, x: 8, y: 142 } },
+          helpers.vttablet.getPanel(config.vttablet.panels.vttabletMysqlExecTimeP95FilterebyInstance) { gridPos: { h: 7, w: 8, x: 16, y: 142 } },
+        ]) { gridPos: { h: 1, w: 24, x: 0, y: 141 } },
+
+        # GC Misc
+        rows_helper.getRow(config.row.misc).addPanels([
+          helpers.os.getPanel(config.vttablet.panels.vttabletGarbageCollectionCount) { gridPos: { h: 7, w: 8, x: 0, y: 150 } },
+          helpers.os.getPanel(config.vttablet.panels.vttabletGarbageCollectionDuration) { gridPos: { h: 7, w: 8, x: 8, y: 150 } },
+          helpers.os.getPanel(config.vttablet.panels.vttabletGarbageCollectionDurationQuantiles) { gridPos: { h: 7, w: 8, x: 16, y: 150 } },
+          helpers.os.getPanel(config.vtgate.panels.vtgateGarbageCollectionCount) { gridPos: { h: 7, w: 8, x: 0, y: 157 } },
+          helpers.os.getPanel(config.vtgate.panels.vtgateGarbageCollectionDuration) { gridPos: { h: 7, w: 8, x: 8, y: 157 } },
+          helpers.os.getPanel(config.vtgate.panels.vtgateGarbageCollectionDurationQuantiles) { gridPos: { h: 7, w: 8, x: 16, y: 157 } },
+        ]) { gridPos: { h: 1, w: 24, x: 0, y: 149 } },
+
+      ]),
+
+  },
+}

--- a/vitess-mixin/dashboards/resources/config/row_config.libsonnet
+++ b/vitess-mixin/dashboards/resources/config/row_config.libsonnet
@@ -8,7 +8,7 @@
     collapse: true,
   },
   queryErrors:: {
-    title: 'Queries/Errors',
+    title: 'Queries/Errors (VtTablet)',
     collapse: true,
   },
   vitessTimings:: {

--- a/vitess-mixin/dashboards/resources/config/vtgate_config.libsonnet
+++ b/vitess-mixin/dashboards/resources/config/vtgate_config.libsonnet
@@ -373,8 +373,19 @@ local vitess_ct = configuration_templates.prometheus_vitess;
               )
             )
           |||,
-          legendFormat: 'Duration p50',
+          legendFormat: 'Duration p50 (vtgate)',
         },
+        {
+          expr: |||
+            histogram_quantile(
+              0.50,
+              sum by(le)(
+                vitess_mixin:vttablet_queries_bucket:rate1m
+              )
+            )
+          |||,
+          legendFormat: 'Duration p50 (vttablet)',
+        }
       ],
     },
 
@@ -414,7 +425,18 @@ local vitess_ct = configuration_templates.prometheus_vitess;
               )
             )
           |||,
-          legendFormat: 'Duration p95',
+          legendFormat: 'Duration p95 (vtgate)',
+        },
+        {
+          expr: |||
+            histogram_quantile(
+              0.95,
+              sum by(le)(
+                vitess_mixin:vttablet_queries_bucket:rate1m
+              )
+            )
+          |||,
+          legendFormat: 'Duration p95 (vttablet)',
         },
       ],
     },
@@ -461,8 +483,24 @@ local vitess_ct = configuration_templates.prometheus_vitess;
                 )
               )
           |||,
-          legendFormat: 'Avg Latency',
+          legendFormat: 'Avg Latency (vtgate)',
         },
+        {
+          expr: |||
+            sum (
+              rate(
+                vttablet_queries_sum[5m]
+              )
+            )
+            /
+            sum (
+              rate(
+                vttablet_queries_count[5m]
+                )
+              )
+          |||,
+          legendFormat: 'Avg Latency (vttablet)',
+        }
       ],
     },
 
@@ -647,7 +685,7 @@ local vitess_ct = configuration_templates.prometheus_vitess;
 
     //TODO crete a recording rule for this prometheus vitess target
     vtgateGarbageCollectionCount: garbage_collector_panel_template {
-      title: 'GC Count',
+      title: 'GC Count (vtgate)',
       format: 'ops',
       targets: [
         {
@@ -668,7 +706,7 @@ local vitess_ct = configuration_templates.prometheus_vitess;
     },
     //TODO crete a recording rule for this prometheus vitess target
     vtgateGarbageCollectionDuration: garbage_collector_panel_template {
-      title: 'GC Duration total per second',
+      title: 'GC Duration total per second (vtgate)',
       description: 'A summary of the pause duration of garbage collection cycles',
       targets: [
         {
@@ -689,7 +727,7 @@ local vitess_ct = configuration_templates.prometheus_vitess;
     },
     //TODO crete a recording rule for this prometheus vitess target
     vtgateGarbageCollectionDurationQuantiles: garbage_collector_panel_template {
-      title: 'GC Duration quantiles',
+      title: 'GC Duration quantiles (vtgate)',
       targets: [
         {
           expr:

--- a/vitess-mixin/dashboards/resources/grafonnet/rows.libsonnet
+++ b/vitess-mixin/dashboards/resources/grafonnet/rows.libsonnet
@@ -4,6 +4,12 @@ local row = grafana.row;
 
 //TODO move all rows to config/row_config.libsonnet and update the layouts to use grafonnet_helper.getRow()
 {
+
+  summary::
+    row.new(
+      title='Summary',
+    ),
+
   connection::
     row.new(
       title='Connection',
@@ -28,7 +34,7 @@ local row = grafana.row;
 
   errors::
     row.new(
-      title='Errors',
+      title='Errors (vtgate)',
       collapse=true,
     ),
 
@@ -96,21 +102,31 @@ local row = grafana.row;
       title='RED - Requests / Error rate / Duration',
     ),
 
+  REDVtgate::
+    row.new(
+      title='RED (vtgate) - Requests / Error rate / Duration',
+    ),
+
+  REDTablet::
+    row.new(
+      title='RED (tablet) - Requests / Error rate / Duration',
+    ),
+
   REDByKeyspace::
     row.new(
-      title='RED (by keyspace)',
+      title='RED (vtgate - by keyspace)',
       collapse=true
     ),
 
   REDByTabletType::
     row.new(
-      title='RED (by tablet type)',
+      title='RED (vtgate - by tablet type)',
       collapse=true
     ),
 
   REDByPlanType::
     row.new(
-      title='RED (by plan type)',
+      title='RED (tablet - by plan type)',
       collapse=true
     ),
 
@@ -122,7 +138,7 @@ local row = grafana.row;
 
   REDByTable::
     row.new(
-      title='RED (by table)',
+      title='RED (tablet - by table)',
       collapse=true
     ),
 

--- a/vitess-mixin/rules/rules.libsonnet
+++ b/vitess-mixin/rules/rules.libsonnet
@@ -216,6 +216,15 @@ local config = import '../config.libsonnet';
           },
         ],
       },
+      {
+        name: 'vitess_mixin_24',
+        rules: [
+          {
+            record: 'vitess_mixin:vttablet_queries_bucket:rate1m',
+            expr: 'sum by(le)(rate(vttablet_queries_bucket[1m]))'
+          }
+        ]
+      }
     ],
   },
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Add a new dashboard to enhance metric observation in the development environment.
Generate the grafana dashboard json file:
```
cd vitess-mixin
ENV='dev' make dashboards_out
```
then you can find a json file named `overview_dev.json`, please refer to [this comment](https://github.com/apecloud/wesql-scale/issues/147#issuecomment-1607207384) to use Grafana and Prometheus locally.
## Related Issue(s)
#147 