### PR TITLE
chore: add coreutils package in dockerfile for a newer version 'ls' c…

### DIFF
--- a/docker/wesqlscale/Dockerfile.release
+++ b/docker/wesqlscale/Dockerfile.release
@@ -107,7 +107,7 @@ FROM docker.io/alpine:3.17
 
 # install tools via apk
 # RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
-RUN apk add --no-cache shadow bash mysql-client && rm -rf /var/cache/apk/*
+RUN apk add --no-cache shadow bash mysql-client coreutils && rm -rf /var/cache/apk/*
 RUN echo 'export PS1="[\u@\h \W]$"' > ~/.bashrc
 
 # export ENV


### PR DESCRIPTION
Add coreutils package because `kbcli cluster list-logs` command need a newer version of 'ls'.
The new image is just slightly larger:
![image](https://github.com/apecloud/wesql-scale/assets/32926461/3472ea0e-c055-4b33-8c6d-e9a86905bb4a)

