### PR TITLE
feat:add jaeger tracing switch to init_cluster.sh

### DIFF
--- a/examples/common/scripts/jaeger-down.sh
+++ b/examples/common/scripts/jaeger-down.sh
@@ -1,0 +1,2 @@
+#!/bin/zsh
+docker stop jaeger

--- a/examples/common/scripts/jaeger-up.sh
+++ b/examples/common/scripts/jaeger-up.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+docker stop jaeger || true
+sleep 4
+docker rm jaeger || true
+sleep 1
+docker run -d --name jaeger \
+  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
+  -p 5775:5775/udp \
+  -p 6831:6831/udp \
+  -p 6832:6832/udp \
+  -p 5778:5778 \
+  -p 16686:16686 \
+  -p 14268:14268 \
+  -p 14250:14250 \
+  -p 9411:9411 \
+  jaegertracing/all-in-one:1.20
+sleep 1

--- a/examples/common/scripts/vtgate-up.sh
+++ b/examples/common/scripts/vtgate-up.sh
@@ -23,6 +23,8 @@ web_port=15001
 grpc_port=15991
 mysql_server_port=15306
 mysql_server_socket_path="/tmp/mysql.sock"
+jaeger_args=${JAEGER_ARGS:-''}
+
 
 # Start vtgate.
 # shellcheck disable=SC2086
@@ -40,6 +42,7 @@ vtgate \
   --service_map 'grpc-vtgateservice' \
   --pid_file $VTDATAROOT/tmp/vtgate.pid \
   --mysql_auth_server_impl none \
+  $jaeger_args \
   > $VTDATAROOT/tmp/vtgate.out 2>&1 &
 
 # Block waiting for vtgate to be listening

--- a/examples/common/scripts/vttablet-up.sh
+++ b/examples/common/scripts/vttablet-up.sh
@@ -26,6 +26,9 @@ uid=$TABLET_UID
 mysql_port=$[17000 + $uid]
 port=$[15000 + $uid]
 grpc_port=$[16000 + $uid]
+jaeger_args=${JAEGER_ARGS:-''}
+
+
 printf -v alias '%s-%010d' $cell $uid
 printf -v tablet_dir 'vt_%010d' $uid
 tablet_hostname=''
@@ -57,6 +60,7 @@ vttablet \
  --pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
  --vtctld_addr http://$hostname:$vtctld_web_port/ \
  --disable_active_reparents \
+ $jaeger_args \
  > $VTDATAROOT/$tablet_dir/vttablet.out 2>&1 &
 
 # Block waiting for the tablet to be listening


### PR DESCRIPTION
enable setup jaeger tracing functionality when init a local mysql cluster. more about [jaeger](https://www.jaegertracing.io/docs/1.48/).
