### PR TITLE
chore:remove docker setup step in mysqltester ci

### DIFF
--- a/.github/workflows/cluster_endtoend_mysqltester.yml
+++ b/.github/workflows/cluster_endtoend_mysqltester.yml
@@ -90,11 +90,6 @@ jobs:
           make build
           make failpoint-disable
 
-      - name: Setup docker
-        if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
-        uses: docker-practice/actions-setup-docker@v1
-        timeout-minutes: 12
-
       - name: Build and Run container
         if: steps.skip-workflow.outputs.skip-workflow == 'false' && steps.changes.outputs.end_to_end == 'true'
         timeout-minutes: 45


### PR DESCRIPTION
github actions setup-docker  seems to install deprecated docker version. 