### PR TITLE
fix: fix rename sql format error

### DIFF
--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -540,7 +540,7 @@ const (
 		WHERE vrepl_id=%a
 		`
 	sqlSwapTables         = "RENAME TABLE `%a` TO `%a`, `%a` TO `%a`, `%a` TO `%a`"
-	sqlRenameTable        = "RENAME TABLE `%a`.`%a` TO `%a`.`%a`"
+	sqlRenameTable        = "RENAME TABLE `%a` TO `%a`"
 	sqlLockTwoTablesWrite = "LOCK TABLES `%a` WRITE, `%a` WRITE"
 	sqlUnlockTables       = "UNLOCK TABLES"
 	sqlCreateSentryTable  = "CREATE TABLE IF NOT EXISTS `%a` (id INT PRIMARY KEY)"


### PR DESCRIPTION
fix formatting error for `rename` statement.
This PR will potentially fix `revert vitess_migration ....` 