### PR TITLE
fix:onlineDDL controller and engine with dbName

### DIFF
--- a/go/vt/binlog/binlogplayer/dbclient.go
+++ b/go/vt/binlog/binlogplayer/dbclient.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,6 +62,7 @@ func (dc *dbClientImpl) handleError(err error) {
 	}
 }
 
+// todo OnlineDDL: remove DBName set by dbConfig
 func (dc *dbClientImpl) DBName() string {
 	params, _ := dc.dbConfig.MysqlParams()
 	return params.DbName

--- a/go/vt/binlog/binlogplayer/fake_dbclient.go
+++ b/go/vt/binlog/binlogplayer/fake_dbclient.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +33,7 @@ type fakeDBClient struct {
 
 // NewFakeDBClient returns a fake DBClient. Its functions return
 // preset responses to requests.
-func NewFakeDBClient() DBClient {
+func NewFakeDBClient(dbName string) DBClient {
 	return &fakeDBClient{}
 }
 

--- a/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2022 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -333,7 +338,7 @@ func (bts *btStream) Recv() (*binlogdatapb.BinlogTransaction, error) {
 //--------------------------------------
 // DBCLient wrapper
 
-func realDBClientFactory() binlogplayer.DBClient {
+func realDBClientFactory(dbName string) binlogplayer.DBClient {
 	return &realDBClient{}
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -27,8 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"vitess.io/vitess/go/vt/sidecardb"
-
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"vitess.io/vitess/go/vt/discovery"
@@ -119,6 +117,9 @@ func newController(ctx context.Context, params map[string]string, dbClientFactor
 	if err := prototext.Unmarshal([]byte(params["source"]), ct.source); err != nil {
 		return nil, err
 	}
+	if ct.source.Keyspace != "" {
+		ct.dbName = ct.source.Keyspace
+	}
 	ct.stopPos = params["stop_pos"]
 
 	if ct.source.GetExternalMysql() == "" {
@@ -139,7 +140,7 @@ func newController(ctx context.Context, params map[string]string, dbClientFactor
 				return nil, err
 			}
 		}
-		tp, err := discovery.NewTabletPicker(sourceTopo, cells, sidecardb.SidecarDBName, ct.source.Shard, tabletTypesStr)
+		tp, err := discovery.NewTabletPicker(sourceTopo, cells, ct.dbName, ct.source.Shard, tabletTypesStr)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +26,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"vitess.io/vitess/go/vt/sidecardb"
 
 	"google.golang.org/protobuf/encoding/prototext"
 
@@ -52,11 +59,12 @@ const (
 // either read-only or self-synchronized.
 type controller struct {
 	vre             *Engine
-	dbClientFactory func() binlogplayer.DBClient
+	dbClientFactory func(dbName string) binlogplayer.DBClient
 	mysqld          mysqlctl.MysqlDaemon
 	blpStats        *binlogplayer.Stats
 
 	id           uint32
+	dbName       string
 	workflow     string
 	source       *binlogdatapb.BinlogSource
 	stopPos      string
@@ -73,7 +81,7 @@ type controller struct {
 
 // newController creates a new controller. Unless a stream is explicitly 'Stopped',
 // this function launches a goroutine to perform continuous vreplication.
-func newController(ctx context.Context, params map[string]string, dbClientFactory func() binlogplayer.DBClient, mysqld mysqlctl.MysqlDaemon, ts *topo.Server, cell, tabletTypesStr string, blpStats *binlogplayer.Stats, vre *Engine) (*controller, error) {
+func newController(ctx context.Context, params map[string]string, dbClientFactory func(dbName string) binlogplayer.DBClient, mysqld mysqlctl.MysqlDaemon, ts *topo.Server, cell, tabletTypesStr string, blpStats *binlogplayer.Stats, vre *Engine) (*controller, error) {
 	if blpStats == nil {
 		blpStats = binlogplayer.NewStats()
 	}
@@ -84,6 +92,7 @@ func newController(ctx context.Context, params map[string]string, dbClientFactor
 		mysqld:          mysqld,
 		blpStats:        blpStats,
 		done:            make(chan struct{}),
+		dbName:          params["db_name"],
 		source:          &binlogdatapb.BinlogSource{},
 	}
 	log.Infof("creating controller with cell: %v, tabletTypes: %v, and params: %v", cell, tabletTypesStr, params)
@@ -130,7 +139,7 @@ func newController(ctx context.Context, params map[string]string, dbClientFactor
 				return nil, err
 			}
 		}
-		tp, err := discovery.NewTabletPicker(sourceTopo, cells, ct.source.Keyspace, ct.source.Shard, tabletTypesStr)
+		tp, err := discovery.NewTabletPicker(sourceTopo, cells, sidecardb.SidecarDBName, ct.source.Shard, tabletTypesStr)
 		if err != nil {
 			return nil, err
 		}
@@ -199,7 +208,7 @@ func (ct *controller) runBlp(ctx context.Context) (err error) {
 		return err
 	}
 
-	dbClient := ct.dbClientFactory()
+	dbClient := ct.dbClientFactory(ct.dbName)
 	if err := dbClient.Connect(); err != nil {
 		return vterrors.Wrap(err, "can't connect to database")
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -88,7 +93,7 @@ func TestControllerKeyRange(t *testing.T) {
 	dbClient.ExpectRequestRE("update mysql.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("commit", nil, nil)
 
-	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
 
 	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "replica", nil, nil)
@@ -124,7 +129,7 @@ func TestControllerTables(t *testing.T) {
 	dbClient.ExpectRequestRE("update mysql.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("commit", nil, nil)
 
-	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{
 		MysqlPort: sync2.NewAtomicInt32(3306),
 		Schema: &tabletmanagerdatapb.SchemaDefinition{
@@ -217,7 +222,7 @@ func TestControllerOverrides(t *testing.T) {
 	dbClient.ExpectRequestRE("update mysql.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("commit", nil, nil)
 
-	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
 
 	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "rdonly", nil, nil)
@@ -285,7 +290,7 @@ func TestControllerRetry(t *testing.T) {
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update mysql.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("commit", nil, nil)
-	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
 
 	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "rdonly", nil, nil)
@@ -345,7 +350,7 @@ func TestControllerStopPosition(t *testing.T) {
 	dbClient.ExpectRequest("commit", nil, nil)
 	dbClient.ExpectRequest("update mysql.vreplication set state='Stopped', message='Reached stopping position, done playing logs' where id=1", testDMLResponse, nil)
 
-	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
 
 	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "replica", nil, nil)

--- a/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
@@ -79,9 +79,10 @@ func TestControllerKeyRange(t *testing.T) {
 	wantTablet := addTablet(100)
 	defer deleteTablet(wantTablet)
 	params := map[string]string{
-		"id":     "1",
-		"state":  binlogplayer.BlpRunning,
-		"source": fmt.Sprintf(`keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
+		"db_name": "vttest",
+		"id":      "1",
+		"state":   binlogplayer.BlpRunning,
+		"source":  fmt.Sprintf(`keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
 	}
 
 	dbClient := binlogplayer.NewMockDBClient(t)
@@ -115,9 +116,10 @@ func TestControllerTables(t *testing.T) {
 	resetBinlogClient()
 
 	params := map[string]string{
-		"id":     "1",
-		"state":  binlogplayer.BlpRunning,
-		"source": fmt.Sprintf(`keyspace:"%s" shard:"0" tables:"table1" tables:"/funtables_/" `, env.KeyspaceName),
+		"db_name": "vttest",
+		"id":      "1",
+		"state":   binlogplayer.BlpRunning,
+		"source":  fmt.Sprintf(`keyspace:"%s" shard:"0" tables:"table1" tables:"/funtables_/" `, env.KeyspaceName),
 	}
 
 	dbClient := binlogplayer.NewMockDBClient(t)
@@ -172,7 +174,8 @@ func TestControllerTables(t *testing.T) {
 
 func TestControllerBadID(t *testing.T) {
 	params := map[string]string{
-		"id": "bad",
+		"db_name": "vttest",
+		"id":      "bad",
 	}
 	_, err := newController(context.Background(), params, nil, nil, nil, "", "", nil, nil)
 	want := `strconv.Atoi: parsing "bad": invalid syntax`
@@ -183,8 +186,9 @@ func TestControllerBadID(t *testing.T) {
 
 func TestControllerStopped(t *testing.T) {
 	params := map[string]string{
-		"id":    "1",
-		"state": binlogplayer.BlpStopped,
+		"db_name": "vttest",
+		"id":      "1",
+		"state":   binlogplayer.BlpStopped,
 	}
 
 	ct, err := newController(context.Background(), params, nil, nil, nil, "", "", nil, nil)
@@ -206,6 +210,7 @@ func TestControllerOverrides(t *testing.T) {
 	defer deleteTablet(wantTablet)
 
 	params := map[string]string{
+		"db_name":      "vttest",
 		"id":           "1",
 		"state":        binlogplayer.BlpRunning,
 		"source":       fmt.Sprintf(`keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
@@ -242,9 +247,10 @@ func TestControllerCanceledContext(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 
 	params := map[string]string{
-		"id":     "1",
-		"state":  binlogplayer.BlpRunning,
-		"source": fmt.Sprintf(`keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
+		"db_name": "vttest",
+		"id":      "1",
+		"state":   binlogplayer.BlpRunning,
+		"source":  fmt.Sprintf(`keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -271,6 +277,7 @@ func TestControllerRetry(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 
 	params := map[string]string{
+		"db_name":      "vttest",
 		"id":           "1",
 		"state":        binlogplayer.BlpRunning,
 		"source":       fmt.Sprintf(`keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
@@ -308,9 +315,10 @@ func TestControllerStopPosition(t *testing.T) {
 	defer deleteTablet(wantTablet)
 
 	params := map[string]string{
-		"id":     "1",
-		"state":  binlogplayer.BlpRunning,
-		"source": fmt.Sprintf(`keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
+		"db_name": "vttest",
+		"id":      "1",
+		"state":   binlogplayer.BlpRunning,
+		"source":  fmt.Sprintf(`keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
 	}
 
 	dbClient := binlogplayer.NewMockDBClient(t)

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -376,7 +376,7 @@ func (vre *Engine) exec(query string, runAsAdmin bool) (*sqltypes.Result, error)
 		return nil, err
 	}
 
-	dbClient := vre.getDBClient(sidecardb.SidecarDBName, runAsAdmin)
+	dbClient := vre.getDBClient(vre.dbName, runAsAdmin)
 	if err := dbClient.Connect(); err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -30,6 +30,8 @@ import (
 	"sync"
 	"time"
 
+	"vitess.io/vitess/go/vt/sidecardb"
+
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/mysql"
@@ -99,15 +101,12 @@ type Engine struct {
 	// cancel will cancel the root context, thereby all controllers.
 	cancel context.CancelFunc
 
-	ts     *topo.Server
-	cell   string
-	mysqld mysqlctl.MysqlDaemon
-	//todo onlineDDL: add a param 'tableSchema' to dbClientFactoryFiltered
-	dbClientFactoryFiltered func() binlogplayer.DBClient
-	//todo onlineDDL: add a param 'tableSchema' to dbClientFactoryDba
-	dbClientFactoryDba func() binlogplayer.DBClient
-	//todo onlineDDL: need to remove default DbName
-	dbName string
+	ts                      *topo.Server
+	cell                    string
+	mysqld                  mysqlctl.MysqlDaemon
+	dbClientFactoryFiltered func(dbName string) binlogplayer.DBClient
+	dbClientFactoryDba      func(dbName string) binlogplayer.DBClient
+	dbName                  string
 
 	journaler map[string]*journalEvent
 	ec        *externalConnector
@@ -149,18 +148,19 @@ func NewEngine(config *tabletenv.TabletConfig, ts *topo.Server, cell string, mys
 	return vre
 }
 
+// todo OnlineDDL: remove Dbname from vre.Engine
 // InitDBConfig should be invoked after the db name is computed.
 func (vre *Engine) InitDBConfig(dbcfgs *dbconfigs.DBConfigs) {
 	// If we're already initilized, it's a test engine. Ignore the call.
 	if vre.dbClientFactoryFiltered != nil && vre.dbClientFactoryDba != nil {
 		return
 	}
-	//todo onlineDDL: remove default DbName
-	vre.dbClientFactoryFiltered = func() binlogplayer.DBClient {
-		return binlogplayer.NewDBClient(dbcfgs.FilteredWithDB())
+	vre.dbClientFactoryFiltered = func(dbName string) binlogplayer.DBClient {
+		dbcfgs.DBName = dbName
+		return binlogplayer.NewDBClient(dbcfgs.DbaWithDB())
 	}
-	//todo onlineDDL: remove default DbName
-	vre.dbClientFactoryDba = func() binlogplayer.DBClient {
+	vre.dbClientFactoryDba = func(dbName string) binlogplayer.DBClient {
+		dbcfgs.DBName = dbName
 		return binlogplayer.NewDBClient(dbcfgs.DbaWithDB())
 	}
 	//todo onlineDDL: remove default DbName
@@ -168,7 +168,7 @@ func (vre *Engine) InitDBConfig(dbcfgs *dbconfigs.DBConfigs) {
 }
 
 // NewTestEngine creates a new Engine for testing.
-func NewTestEngine(ts *topo.Server, cell string, mysqld mysqlctl.MysqlDaemon, dbClientFactoryFiltered func() binlogplayer.DBClient, dbClientFactoryDba func() binlogplayer.DBClient, dbname string, externalConfig map[string]*dbconfigs.DBConfigs) *Engine {
+func NewTestEngine(ts *topo.Server, cell string, mysqld mysqlctl.MysqlDaemon, dbClientFactoryFiltered func(dbName string) binlogplayer.DBClient, dbClientFactoryDba func(dbName string) binlogplayer.DBClient, dbname string, externalConfig map[string]*dbconfigs.DBConfigs) *Engine {
 	vre := &Engine{
 		controllers:             make(map[int]*controller),
 		ts:                      ts,
@@ -185,7 +185,7 @@ func NewTestEngine(ts *topo.Server, cell string, mysqld mysqlctl.MysqlDaemon, db
 
 // NewSimpleTestEngine creates a new Engine for testing that can
 // also short curcuit functions as needed.
-func NewSimpleTestEngine(ts *topo.Server, cell string, mysqld mysqlctl.MysqlDaemon, dbClientFactoryFiltered func() binlogplayer.DBClient, dbClientFactoryDba func() binlogplayer.DBClient, dbname string, externalConfig map[string]*dbconfigs.DBConfigs) *Engine {
+func NewSimpleTestEngine(ts *topo.Server, cell string, mysqld mysqlctl.MysqlDaemon, dbClientFactoryFiltered func(dbName string) binlogplayer.DBClient, dbClientFactoryDba func(dbName string) binlogplayer.DBClient, dbname string, externalConfig map[string]*dbconfigs.DBConfigs) *Engine {
 	vre := &Engine{
 		controllers:             make(map[int]*controller),
 		ts:                      ts,
@@ -334,9 +334,9 @@ func (vre *Engine) Close() {
 
 func (vre *Engine) getDBClient(isAdmin bool) binlogplayer.DBClient {
 	if isAdmin {
-		return vre.dbClientFactoryDba()
+		return vre.dbClientFactoryDba(sidecardb.SidecarDBName)
 	}
-	return vre.dbClientFactoryFiltered()
+	return vre.dbClientFactoryFiltered(sidecardb.SidecarDBName)
 }
 
 // ExecWithDBA runs the specified query as the DBA user
@@ -647,7 +647,7 @@ func (vre *Engine) transitionJournal(je *journalEvent) {
 		vre.controllers[refid].Stop()
 	}
 
-	dbClient := vre.dbClientFactoryFiltered()
+	dbClient := vre.dbClientFactoryFiltered(sidecardb.SidecarDBName)
 	if err := dbClient.Connect(); err != nil {
 		log.Errorf("transitionJournal: unable to connect to the database: %v", err)
 		return
@@ -747,7 +747,7 @@ func (vre *Engine) WaitForPos(ctx context.Context, id int, pos string) error {
 		return nil
 	}
 
-	dbClient := vre.dbClientFactoryFiltered()
+	dbClient := vre.dbClientFactoryFiltered(sidecardb.SidecarDBName)
 	if err := dbClient.Connect(); err != nil {
 		return err
 	}
@@ -825,7 +825,7 @@ func (vre *Engine) updateStats() {
 }
 
 func (vre *Engine) readAllRows(ctx context.Context) ([]map[string]string, error) {
-	dbClient := vre.dbClientFactoryFiltered()
+	dbClient := vre.dbClientFactoryFiltered(sidecardb.SidecarDBName)
 	if err := dbClient.Connect(); err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -332,11 +332,11 @@ func (vre *Engine) Close() {
 	log.Infof("VReplication Engine: closed")
 }
 
-func (vre *Engine) getDBClient(isAdmin bool) binlogplayer.DBClient {
+func (vre *Engine) getDBClient(dbName string, isAdmin bool) binlogplayer.DBClient {
 	if isAdmin {
-		return vre.dbClientFactoryDba(sidecardb.SidecarDBName)
+		return vre.dbClientFactoryDba(dbName)
 	}
-	return vre.dbClientFactoryFiltered(sidecardb.SidecarDBName)
+	return vre.dbClientFactoryFiltered(dbName)
 }
 
 // ExecWithDBA runs the specified query as the DBA user
@@ -376,7 +376,7 @@ func (vre *Engine) exec(query string, runAsAdmin bool) (*sqltypes.Result, error)
 		return nil, err
 	}
 
-	dbClient := vre.getDBClient(runAsAdmin)
+	dbClient := vre.getDBClient(sidecardb.SidecarDBName, runAsAdmin)
 	if err := dbClient.Connect(); err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -30,6 +30,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/sidecardb"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -482,9 +484,9 @@ func TestGetDBClient(t *testing.T) {
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
 	vre := NewTestEngine(env.TopoServ, env.Cells[0], mysqld, dbClientFactoryFiltered, dbClientFactoryDba, dbClientDba.DBName(), nil)
 
-	shouldBeDbaClient := vre.getDBClient(true /*runAsAdmin*/)
+	shouldBeDbaClient := vre.getDBClient(sidecardb.SidecarDBName, true /*runAsAdmin*/)
 	assert.Equal(t, shouldBeDbaClient, dbClientDba)
 
-	shouldBeFilteredClient := vre.getDBClient(false /*runAsAdmin*/)
+	shouldBeFilteredClient := vre.getDBClient(sidecardb.SidecarDBName, false /*runAsAdmin*/)
 	assert.Equal(t, shouldBeFilteredClient, dbClientFiltered)
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,7 +45,7 @@ func TestEngineOpen(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 	resetBinlogClient()
 	dbClient := binlogplayer.NewMockDBClient(t)
-	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
 
 	vre := NewTestEngine(env.TopoServ, env.Cells[0], mysqld, dbClientFactory, dbClientFactory, dbClient.DBName(), nil)
@@ -80,7 +85,7 @@ func TestEngineOpenRetry(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 	resetBinlogClient()
 	dbClient := binlogplayer.NewMockDBClient(t)
-	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
 
 	vre := NewTestEngine(env.TopoServ, env.Cells[0], mysqld, dbClientFactory, dbClientFactory, dbClient.DBName(), nil)
@@ -141,7 +146,7 @@ func TestEngineExec(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 	resetBinlogClient()
 	dbClient := binlogplayer.NewMockDBClient(t)
-	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
 
 	// Test Insert
@@ -305,7 +310,7 @@ func TestEngineBadInsert(t *testing.T) {
 	resetBinlogClient()
 
 	dbClient := binlogplayer.NewMockDBClient(t)
-	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
 
 	vre := NewTestEngine(env.TopoServ, env.Cells[0], mysqld, dbClientFactory, dbClientFactory, dbClient.DBName(), nil)
@@ -333,7 +338,7 @@ func TestEngineSelect(t *testing.T) {
 	resetBinlogClient()
 	dbClient := binlogplayer.NewMockDBClient(t)
 
-	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
 
 	vre := NewTestEngine(env.TopoServ, env.Cells[0], mysqld, dbClientFactory, dbClientFactory, dbClient.DBName(), nil)
@@ -368,7 +373,7 @@ func TestWaitForPos(t *testing.T) {
 
 	dbClient := binlogplayer.NewMockDBClient(t)
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
-	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbClient }
 	vre := NewTestEngine(env.TopoServ, env.Cells[0], mysqld, dbClientFactory, dbClientFactory, dbClient.DBName(), nil)
 
 	dbClient.ExpectRequest("select * from mysql.vreplication where db_name='db'", &sqltypes.Result{}, nil)
@@ -396,7 +401,7 @@ func TestWaitForPos(t *testing.T) {
 func TestWaitForPosError(t *testing.T) {
 	dbClient := binlogplayer.NewMockDBClient(t)
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
-	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbClient }
 	vre := NewTestEngine(env.TopoServ, env.Cells[0], mysqld, dbClientFactory, dbClientFactory, dbClient.DBName(), nil)
 
 	err := vre.WaitForPos(context.Background(), 1, "MariaDB/0-1-1084")
@@ -432,7 +437,7 @@ func TestWaitForPosError(t *testing.T) {
 func TestWaitForPosCancel(t *testing.T) {
 	dbClient := binlogplayer.NewMockDBClient(t)
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
-	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbClient }
 	vre := NewTestEngine(env.TopoServ, env.Cells[0], mysqld, dbClientFactory, dbClientFactory, dbClient.DBName(), nil)
 
 	dbClient.ExpectRequest("select * from mysql.vreplication where db_name='db'", &sqltypes.Result{}, nil)
@@ -471,8 +476,8 @@ func TestWaitForPosCancel(t *testing.T) {
 func TestGetDBClient(t *testing.T) {
 	dbClientDba := binlogplayer.NewMockDbaClient(t)
 	dbClientFiltered := binlogplayer.NewMockDBClient(t)
-	dbClientFactoryDba := func() binlogplayer.DBClient { return dbClientDba }
-	dbClientFactoryFiltered := func() binlogplayer.DBClient { return dbClientFiltered }
+	dbClientFactoryDba := func(dbName string) binlogplayer.DBClient { return dbClientDba }
+	dbClientFactoryFiltered := func(dbName string) binlogplayer.DBClient { return dbClientFiltered }
 
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
 	vre := NewTestEngine(env.TopoServ, env.Cells[0], mysqld, dbClientFactoryFiltered, dbClientFactoryDba, dbClientDba.DBName(), nil)

--- a/go/vt/vttablet/tabletmanager/vreplication/flags.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/flags.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2022 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +30,7 @@ import (
 )
 
 var (
-	retryDelay          = 5 * time.Second
+	retryDelay          = 1 * time.Second
 	maxTimeToRetryError time.Duration // default behavior is to keep retrying, for backward compatibility
 
 	tabletTypesStr = "in_order:REPLICA,PRIMARY"

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -370,7 +375,7 @@ func expectFBCRequest(t *testing.T, tablet *topodatapb.Tablet, pos string, table
 //--------------------------------------
 // DBCLient wrapper
 
-func realDBClientFactory() binlogplayer.DBClient {
+func realDBClientFactory(dbName string) binlogplayer.DBClient {
 	return &realDBClient{}
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +29,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"vitess.io/vitess/go/vt/sidecardb"
 
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
@@ -442,7 +449,7 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 				go func() {
 					gcQuery := fmt.Sprintf("delete from mysql.copy_state where vrepl_id = %d and table_name = %s and id < (select maxid from (select max(id) as maxid from mysql.copy_state where vrepl_id = %d and table_name = %s) as depsel)",
 						vc.vr.id, encodeString(tableName), vc.vr.id, encodeString(tableName))
-					dbClient := vc.vr.vre.getDBClient(false)
+					dbClient := vc.vr.vre.getDBClient(sidecardb.SidecarDBName, false)
 					if err := dbClient.Connect(); err != nil {
 						log.Errorf("Error while garbage collecting older copy_state rows, could not connect to database: %v", err)
 						return

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +31,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"vitess.io/vitess/go/vt/sidecardb"
 
 	"github.com/spyzhov/ajson"
 	"github.com/stretchr/testify/require"
@@ -111,7 +118,7 @@ func TestHeartbeatFrequencyFlag(t *testing.T) {
 	}()
 
 	stats := binlogplayer.NewStats()
-	vp := &vplayer{vr: &vreplicator{dbClient: newVDBClient(realDBClientFactory(), stats), stats: stats}}
+	vp := &vplayer{vr: &vreplicator{dbClient: newVDBClient(realDBClientFactory(sidecardb.SidecarDBName), stats), stats: stats}}
 
 	type testcount struct {
 		count      int
@@ -2672,7 +2679,7 @@ func TestPlayerJSONTwoColumns(t *testing.T) {
 
 func TestVReplicationLogs(t *testing.T) {
 	defer deleteTablet(addTablet(100))
-	dbClient := playerEngine.dbClientFactoryDba()
+	dbClient := playerEngine.dbClientFactoryDba(sidecardb.SidecarDBName)
 	err := dbClient.Connect()
 	require.NoError(t, err)
 	defer dbClient.Close()

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +29,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"vitess.io/vitess/go/vt/sidecardb"
 
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/schema"
@@ -793,7 +800,7 @@ func (vr *vreplicator) execPostCopyActions(ctx context.Context, tableName string
 			if connID < 1 {
 				return fmt.Errorf("invalid connection ID found (%d) when attempting to kill %q", connID, ak.Task)
 			}
-			killdbc := vr.vre.dbClientFactoryDba()
+			killdbc := vr.vre.dbClientFactoryDba(sidecardb.SidecarDBName)
 			if err := killdbc.Connect(); err != nil {
 				return fmt.Errorf("unable to connect to the database when attempting to kill %q: %v", ak.Task, err)
 			}
@@ -983,7 +990,7 @@ func (vr *vreplicator) supportsDeferredSecondaryKeys() bool {
 }
 
 func (vr *vreplicator) newClientConnection(ctx context.Context) (*vdbClient, error) {
-	dbc := vr.vre.dbClientFactoryFiltered()
+	dbc := vr.vre.dbClientFactoryFiltered(sidecardb.SidecarDBName)
 	if err := dbc.Connect(); err != nil {
 		return nil, vterrors.Wrap(err, "can't connect to database")
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +32,8 @@ import (
 	"testing"
 	"time"
 	"unicode"
+
+	"vitess.io/vitess/go/vt/sidecardb"
 
 	"github.com/buger/jsonparser"
 	"github.com/stretchr/testify/assert"
@@ -207,7 +214,7 @@ func TestDeferSecondaryKeys(t *testing.T) {
 	id := uint32(1)
 	vsclient := newTabletConnector(tablet)
 	stats := binlogplayer.NewStats()
-	dbClient := playerEngine.dbClientFactoryFiltered()
+	dbClient := playerEngine.dbClientFactoryFiltered(sidecardb.SidecarDBName)
 	err := dbClient.Connect()
 	require.NoError(t, err)
 	defer dbClient.Close()
@@ -538,11 +545,11 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 	id := uint32(1)
 	vsclient := newTabletConnector(tablet)
 	stats := binlogplayer.NewStats()
-	dbaconn := playerEngine.dbClientFactoryDba()
+	dbaconn := playerEngine.dbClientFactoryDba(sidecardb.SidecarDBName)
 	err = dbaconn.Connect()
 	require.NoError(t, err)
 	defer dbaconn.Close()
-	dbClient := playerEngine.dbClientFactoryFiltered()
+	dbClient := playerEngine.dbClientFactoryFiltered(sidecardb.SidecarDBName)
 	err = dbClient.Connect()
 	require.NoError(t, err)
 	defer dbClient.Close()

--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -445,7 +445,7 @@ func (tme *testMigraterEnv) createDBClients(ctx context.Context, t *testing.T) {
 	for _, primary := range tme.sourcePrimaries {
 		dbclient := newFakeDBClient(primary.Tablet.Alias.String())
 		tme.dbSourceClients = append(tme.dbSourceClients, dbclient)
-		dbClientFactory := func() binlogplayer.DBClient { return dbclient }
+		dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbclient }
 		// Replace existing engine with a new one
 		primary.TM.VREngine = vreplication.NewTestEngine(tme.ts, "", primary.FakeMysqlDaemon, dbClientFactory, dbClientFactory, dbclient.DBName(), nil)
 		primary.TM.VREngine.Open(ctx)
@@ -454,7 +454,7 @@ func (tme *testMigraterEnv) createDBClients(ctx context.Context, t *testing.T) {
 		log.Infof("Adding as targetPrimary %s", primary.Tablet.Alias)
 		dbclient := newFakeDBClient(primary.Tablet.Alias.String())
 		tme.dbTargetClients = append(tme.dbTargetClients, dbclient)
-		dbClientFactory := func() binlogplayer.DBClient { return dbclient }
+		dbClientFactory := func(dbName string) binlogplayer.DBClient { return dbclient }
 		// Replace existing engine with a new one
 		primary.TM.VREngine = vreplication.NewTestEngine(tme.ts, "", primary.FakeMysqlDaemon, dbClientFactory, dbClientFactory, dbclient.DBName(), nil)
 		primary.TM.VREngine.Open(ctx)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the WeScale project.
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Removed the strong binding between Engine and dbName in vreplication, allowing dbName to be bound to each onlineDDL task.
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
