### PR TITLE
feat: add 'example' value on executing show failpoints

### DIFF
--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -2,7 +2,7 @@
 
 name: Cluster (onlineddl_scheduler)
 on:
-#  pull_request:
+  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler_mysql57.yml
@@ -2,7 +2,7 @@
 
 name: Cluster (onlineddl_scheduler) mysql57
 on:
-#  pull_request:
+  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -2,7 +2,7 @@
 
 name: Cluster (onlineddl_vrepl)
 on:
-#  pull_request:
+  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_mysql57.yml
@@ -2,7 +2,7 @@
 
 name: Cluster (onlineddl_vrepl) mysql57
 on:
-#  pull_request:
+  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -2,7 +2,7 @@
 
 name: Cluster (onlineddl_vrepl_stress)
 on:
-#  pull_request:
+  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_mysql57.yml
@@ -2,7 +2,7 @@
 
 name: Cluster (onlineddl_vrepl_stress) mysql57
 on:
-#  pull_request:
+  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -2,7 +2,7 @@
 
 name: Cluster (onlineddl_vrepl_stress_suite)
 on:
-#  pull_request:
+  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite_mysql57.yml
@@ -2,7 +2,7 @@
 
 name: Cluster (onlineddl_vrepl_stress_suite) mysql57
 on:
-#  pull_request:
+  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -2,7 +2,7 @@
 
 name: Cluster (onlineddl_vrepl_suite)
 on:
-#  pull_request:
+  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite_mysql57.yml
@@ -2,7 +2,7 @@
 
 name: Cluster (onlineddl_vrepl_suite) mysql57
 on:
-#  pull_request:
+  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/go/vt/failpointkey/failpoint_keys.go
+++ b/go/vt/failpointkey/failpoint_keys.go
@@ -7,33 +7,39 @@ package failpointkey
 
 import "github.com/pingcap/failpoint"
 
-type FailpointKey struct {
-	FullName string
-	Name     string
+type FailpointValue struct {
+	FullName   string
+	Name       string
+	ExampleStr string
 }
 
-var FailpointTable map[string]string
+var FailpointTable map[string]FailpointValue
 
 var (
-	TestFailPointError = FailpointKey{
-		FullName: "TestFailPointError",
-		Name:     "TestFailPointError",
+	TestFailPointError = FailpointValue{
+		FullName:   "TestFailPointError",
+		Name:       "TestFailPointError",
+		ExampleStr: "",
 	}
-	CreateDatabaseErrorOnDbname = FailpointKey{
-		FullName: "vitess.io/vitess/go/vt/topotools/create-database-error-on-dbname",
-		Name:     "create-database-error-on-dbname",
+	CreateDatabaseErrorOnDbname = FailpointValue{
+		FullName:   "vitess.io/vitess/go/vt/topotools/create-database-error-on-dbname",
+		Name:       "create-database-error-on-dbname",
+		ExampleStr: "return(db)",
 	}
-	IsVReplMigrationReadyToCutOver = FailpointKey{
-		FullName: "vitess.io/vitess/go/vt/vttablet/onlineddl/IsVReplMigrationReadyToCutOver",
-		Name:     "IsVReplMigrationReadyToCutOver",
+	IsVReplMigrationReadyToCutOver = FailpointValue{
+		FullName:   "vitess.io/vitess/go/vt/vttablet/onlineddl/IsVReplMigrationReadyToCutOver",
+		Name:       "IsVReplMigrationReadyToCutOver",
+		ExampleStr: "return(true)",
 	}
-	WaitJustBeforeStopVreplication = FailpointKey{
-		FullName: "vitess.io/vitess/go/vt/vttablet/onlineddl/WaitJustBeforeStopVreplication",
-		Name:     "WaitJustBeforeStopVreplication",
+	WaitJustBeforeStopVreplication = FailpointValue{
+		FullName:   "vitess.io/vitess/go/vt/vttablet/onlineddl/WaitJustBeforeStopVreplication",
+		Name:       "WaitJustBeforeStopVreplication",
+		ExampleStr: "return(true)",
 	}
-	WaitJustAfterStopVreplication = FailpointKey{
-		FullName: "vitess.io/vitess/go/vt/vttablet/onlineddl/WaitJustAfterStopVreplication",
-		Name:     "WaitJustAfterStopVreplication",
+	WaitJustAfterStopVreplication = FailpointValue{
+		FullName:   "vitess.io/vitess/go/vt/vttablet/onlineddl/WaitJustAfterStopVreplication",
+		Name:       "WaitJustAfterStopVreplication",
+		ExampleStr: "return(true)",
 	}
 )
 
@@ -42,10 +48,10 @@ func init() {
 	if err != nil {
 		return
 	}
-	FailpointTable = make(map[string]string)
-	FailpointTable[CreateDatabaseErrorOnDbname.FullName] = CreateDatabaseErrorOnDbname.Name
-	FailpointTable[TestFailPointError.FullName] = TestFailPointError.Name
-	FailpointTable[IsVReplMigrationReadyToCutOver.FullName] = IsVReplMigrationReadyToCutOver.Name
-	FailpointTable[WaitJustBeforeStopVreplication.FullName] = WaitJustBeforeStopVreplication.Name
-	FailpointTable[WaitJustAfterStopVreplication.FullName] = WaitJustAfterStopVreplication.Name
+	FailpointTable = make(map[string]FailpointValue)
+	FailpointTable[CreateDatabaseErrorOnDbname.FullName] = CreateDatabaseErrorOnDbname
+	FailpointTable[TestFailPointError.FullName] = TestFailPointError
+	FailpointTable[IsVReplMigrationReadyToCutOver.FullName] = IsVReplMigrationReadyToCutOver
+	FailpointTable[WaitJustBeforeStopVreplication.FullName] = WaitJustBeforeStopVreplication
+	FailpointTable[WaitJustAfterStopVreplication.FullName] = WaitJustAfterStopVreplication
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -887,7 +887,7 @@ func (e *Executor) showFailPoint(filter *sqlparser.ShowFilter) (*sqltypes.Result
 		if err == nil {
 			Enabled = true
 		}
-		rows = append(rows, buildVarCharRow(key, boolToString(Enabled)))
+		rows = append(rows, buildVarCharRow(key, boolToString(Enabled), failpointkey.FailpointTable[key].ExampleStr))
 	}
 	// then show failpoint not in static map but in failpoint.List()
 	for _, key := range failpoint.List() {
@@ -897,11 +897,11 @@ func (e *Executor) showFailPoint(filter *sqlparser.ShowFilter) (*sqltypes.Result
 			if err == nil {
 				Enabled = true
 			}
-			rows = append(rows, buildVarCharRow(key, boolToString(Enabled)))
+			rows = append(rows, buildVarCharRow(key, boolToString(Enabled), failpointkey.FailpointTable[key].ExampleStr))
 		}
 	}
 	return &sqltypes.Result{
-		Fields: buildVarCharFields("failpoint keys", "Enabled"),
+		Fields: buildVarCharFields("failpoint keys", "Enabled", "Example"),
 		Rows:   rows,
 	}, nil
 }


### PR DESCRIPTION

## Description
Add an 'Example' column when executing the show failpoints command. For example:
```sql
mysql> show failpoints;
+--------------------------------------------------------------------------+---------+--------------+
| failpoint keys                                                           | Enabled | Example      |
+--------------------------------------------------------------------------+---------+--------------+
| vitess.io/vitess/go/vt/topotools/create-database-error-on-dbname         | false   | return(db)   |
| TestFailPointError                                                       | false   |              |
| vitess.io/vitess/go/vt/vttablet/onlineddl/IsVReplMigrationReadyToCutOver | false   | return(true) |
| vitess.io/vitess/go/vt/vttablet/onlineddl/WaitJustBeforeStopVreplication | false   | return(true) |
| vitess.io/vitess/go/vt/vttablet/onlineddl/WaitJustAfterStopVreplication  | false   | return(true) |
| vitess.io/vitess/go/vt/vtgate/OpenSetFailPoint                           | true    |              |
+--------------------------------------------------------------------------+---------+--------------+
6 rows in set (0.00 sec)
```
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
#362 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

