### PR TITLE
fix: onlineDDL_scheduler_resume_bug

### DIFF
--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -602,7 +602,8 @@ func testPause(t *testing.T) {
 		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid1, 10*time.Minute, schema.OnlineDDLStatusRunning)
 		checkArtifactsOfMigration(t, uuid1, artifacts1)
 
-		testOnlineDDLStatement(t, createParams(AlterT1StatementDropCol4, ddlStrategy, "vtgate", "", "", false))
+		testOnlineDDLStatement(t, createParams(AlterT1StatementDropCol4, ddlStrategy, "vtgate", "", "", true))
+		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid1, 10*time.Minute, schema.OnlineDDLStatusComplete)
 		checkTableColNotExist(t, t1Name, "new_col14")
 	})
 

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -602,8 +602,8 @@ func testPause(t *testing.T) {
 		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid1, 10*time.Minute, schema.OnlineDDLStatusRunning)
 		checkArtifactsOfMigration(t, uuid1, artifacts1)
 
-		testOnlineDDLStatement(t, createParams(AlterT1StatementDropCol4, ddlStrategy, "vtgate", "", "", true))
-		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid1, 10*time.Minute, schema.OnlineDDLStatusComplete)
+		uuid2 := testOnlineDDLStatement(t, createParams(AlterT1StatementDropCol4, ddlStrategy, "vtgate", "", "", true))
+		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid2, 10*time.Minute, schema.OnlineDDLStatusComplete)
 		checkTableColNotExist(t, t1Name, "new_col14")
 	})
 

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -253,7 +253,7 @@ func TestMain(m *testing.M) {
 
 func TestSchemaChange(t *testing.T) {
 	t.Run("initSchema", initSchema)
-	//t.Run("scheduler", testScheduler)
+	t.Run("scheduler", testScheduler)
 	t.Run("pause", testPause)
 
 	//t.Run("singleton", testSingleton)

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -253,7 +253,7 @@ func TestMain(m *testing.M) {
 
 func TestSchemaChange(t *testing.T) {
 	t.Run("initSchema", initSchema)
-	t.Run("scheduler", testScheduler)
+	//t.Run("scheduler", testScheduler)
 	t.Run("pause", testPause)
 
 	//t.Run("singleton", testSingleton)
@@ -295,6 +295,22 @@ func checkStateBeforePauseOfMigration(t *testing.T, uuid, expectState string) {
 	require.NotNil(t, rs)
 	assert.Equal(t, 1, len(rs.Named().Rows))
 	assert.Equal(t, expectState, rs.Named().Rows[0].AsString("status_before_paused", ""))
+}
+
+func getArtifactsOfMigration(t *testing.T, uuid string) string {
+	rs := onlineddl.ReadMigrations(t, &vtParams, uuid)
+	require.NotNil(t, rs)
+	assert.Equal(t, 1, len(rs.Named().Rows))
+	return rs.Named().Rows[0].AsString("artifacts", "")
+}
+
+func checkArtifactsOfMigration(t *testing.T, uuid, expectArtifacts string) {
+	rs := onlineddl.ReadMigrations(t, &vtParams, uuid)
+	require.NotNil(t, rs)
+	assert.Equal(t, 1, len(rs.Named().Rows))
+	actualArtifacts := rs.Named().Rows[0].AsString("artifacts", "")
+	fmt.Printf("expectArtifacts is %s, actualArtifacts is %s", expectArtifacts, actualArtifacts)
+	assert.Equal(t, expectArtifacts, actualArtifacts)
 }
 
 func checkStateOfVreplication(t *testing.T, uuid, expectState string) {
@@ -402,6 +418,9 @@ func testPause(t *testing.T) {
 		AlterT1StatementAddCol3 = `
 			ALTER TABLE pause_test1 add column new_col13 int;
 		`
+		AlterT1StatementAddCol4 = `
+			ALTER TABLE pause_test1 add column new_col14 int;
+		`
 		AlterT1StatementDropCol1 = `
 			ALTER TABLE pause_test1 drop column new_col11;
 		`
@@ -410,6 +429,9 @@ func testPause(t *testing.T) {
 			`
 		AlterT1StatementDropCol3 = `
 			ALTER TABLE pause_test1 drop column new_col13;
+		`
+		AlterT1StatementDropCol4 = `
+			ALTER TABLE pause_test1 drop column new_col14;
 		`
 
 		AlterT2StatementAddCol1 = `
@@ -532,6 +554,8 @@ func testPause(t *testing.T) {
 		uuid2 := testOnlineDDLStatement(t, createParams(AlterT2StatementAddCol2, ddlStrategy, "vtgate", "", "", true))
 		uuid3 := testOnlineDDLStatement(t, createParams(AlterT2StatementAddCol3, ddlStrategy, "vtgate", "", "", true))
 
+		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid1, 10*time.Minute, schema.OnlineDDLStatusRunning)
+
 		onlineddl.VtgateExecQuery(t, &vtParams, PauseAllOnlineDDLStatement, "")
 
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid1, schema.OnlineDDLStatusPaused)
@@ -554,6 +578,32 @@ func testPause(t *testing.T) {
 		checkTableColExist(t, t2Name, "new_col22")
 		checkTableColExist(t, t2Name, "new_col23")
 
+	})
+
+	// test of artifacts
+	t.Run("artifacts", func(t *testing.T) {
+		// artifacts should remain unchanged regardless of how many times "pause" and "resume"
+		uuid1 := testOnlineDDLStatement(t, createParams(AlterT1StatementAddCol4, ddlStrategy, "vtgate", "", "", true))
+
+		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid1, 10*time.Minute, schema.OnlineDDLStatusRunning)
+		onlineddl.VtgateExecQuery(t, &vtParams, fmt.Sprintf(PauseOnlineDDLStatement, uuid1), "")
+
+		artifacts1 := getArtifactsOfMigration(t, uuid1)
+		onlineddl.VtgateExecQuery(t, &vtParams, fmt.Sprintf(ResumeOnlineDDLStatement, uuid1), "")
+		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid1, 10*time.Minute, schema.OnlineDDLStatusRunning)
+		// ensure no extra shadow tables are added
+		checkArtifactsOfMigration(t, uuid1, artifacts1)
+
+		// pause second times
+		onlineddl.VtgateExecQuery(t, &vtParams, fmt.Sprintf(PauseOnlineDDLStatement, uuid1), "")
+		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid1, schema.OnlineDDLStatusPaused)
+		// resume again
+		onlineddl.VtgateExecQuery(t, &vtParams, fmt.Sprintf(ResumeOnlineDDLStatement, uuid1), "")
+		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid1, 10*time.Minute, schema.OnlineDDLStatusRunning)
+		checkArtifactsOfMigration(t, uuid1, artifacts1)
+
+		testOnlineDDLStatement(t, createParams(AlterT1StatementDropCol4, ddlStrategy, "vtgate", "", "", false))
+		checkTableColNotExist(t, t1Name, "new_col14")
 	})
 
 	// test of --postpone-launch, resume before launch

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1595,9 +1595,9 @@ func (e *Executor) updateMigrationStatusQueued(ctx context.Context, uuid string)
 	return err
 }
 
-func (e *Executor) clearMigrationStatusBeforePaused(ctx context.Context, uuid string) error {
-	log.Infof("clearMigrationStatusBeforePaused: set status before paused of migration: %s as NULL ", uuid)
-	query, err := sqlparser.ParseAndBind(sqlClearMigrationStatusBefore,
+func (e *Executor) clearMigrationStatusBeforePausedAndSetRunning(ctx context.Context, uuid string) error {
+	log.Infof("clearMigrationStatusBeforePausedAndSetRunning: set status before paused of migration: %s as NULL, and set status as 'running'", uuid)
+	query, err := sqlparser.ParseAndBind(sqlClearMigrationStatusBeforeAndSetRunning,
 		sqltypes.StringBindVariable(uuid),
 	)
 	if err != nil {
@@ -3076,7 +3076,7 @@ func (e *Executor) runNextMigration(ctx context.Context) error {
 		if err = e.continueVReplMigration(ctx, onlineDDLToRunContinue.Schema, onlineDDLToRunContinue.UUID); err != nil {
 			return err
 		}
-		if err = e.clearMigrationStatusBeforePaused(ctx, onlineDDLToRunContinue.UUID); err != nil {
+		if err = e.clearMigrationStatusBeforePausedAndSetRunning(ctx, onlineDDLToRunContinue.UUID); err != nil {
 			return err
 		}
 		log.Infof("Executor.runNextMigration: migration %s was paused while running and unpaused , it is non conflicting and will be executed next", onlineDDLToRunContinue.UUID)

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -127,8 +127,9 @@ const (
 		WHERE
 			migration_uuid=%a
 	`
-	sqlClearMigrationStatusBefore = `UPDATE mysql.schema_migrations
-			SET status_before_paused= NULL
+	sqlClearMigrationStatusBeforeAndSetRunning = `UPDATE mysql.schema_migrations
+			SET status_before_paused= NULL,
+			    migration_status='running'
 		WHERE
 			migration_uuid=%a
 	`


### PR DESCRIPTION
## Description

When the paused migration with running status before paused was resumed, it will create another shadow table.  The reason is the migration status is not changed to 'running' immediately when  vreplication continue to run.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Checklist

-   e2e Tests were added
