### PR TITLE
fix: fix onlineddl pause code bug that involves table comparing

### DIFF
--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -57,7 +57,8 @@ const (
 	`
 	sqlSelectMigrationsPausedWhenQueued = `SELECT
 			id,
-			mysql_table
+			mysql_table,
+			mysql_schema
 		FROM mysql.schema_migrations
 		WHERE
 			migration_status='paused'
@@ -66,7 +67,8 @@ const (
 	`
 	sqlSelectMigrationsPausedWhenReadyOrRunning = `SELECT
 			id,
-			mysql_table
+			mysql_table,
+			mysql_schema
 		FROM mysql.schema_migrations
 		WHERE
 			migration_status='paused'
@@ -77,6 +79,7 @@ const (
 	sqlSelectQueuedMigrations = `SELECT
 			id,
 			mysql_table,
+			mysql_schema,
     		migration_uuid,
 			ddl_action,
 			is_view,
@@ -470,7 +473,8 @@ const (
 	sqlSelectReadyMigrations = `SELECT
     		id,
 			migration_uuid,
-			mysql_table
+			mysql_table,
+			mysql_schema
 		FROM mysql.schema_migrations
 		WHERE
 			migration_status='ready'


### PR DESCRIPTION
## Description

fix bugs in online ddl pause code, should compare not only the table names but also the table schema when determining if two onlineDDL tasks are acting on the same table
