### PR TITLE
fix: add viper handlers for some params

### DIFF
--- a/.checklicenseignore
+++ b/.checklicenseignore
@@ -47,3 +47,5 @@ go/vt/vttablet/tabletserver/planbuilder/cached_size.go
 docker/*
 docker/bootstrap/*
 docker/lite/Dockerfile.*
+
+go/viperutil/test/

--- a/go/viperutil/test/vtgate.cnf
+++ b/go/viperutil/test/vtgate.cnf
@@ -19,3 +19,5 @@ mysql_server_require_secure_transport = false
 mysql_auth_server_static_file         = 
 mysql_server_ssl_key                  = 
 mysql_server_ssl_cert                 = 
+enable_display_sql_execution_vttablets    = true
+enable_read_write_split_for_read_only_txn = true

--- a/go/viperutil/test/vtgate_test_modify.cnf
+++ b/go/viperutil/test/vtgate_test_modify.cnf
@@ -1,26 +1,23 @@
-# Copyright ApeCloud, Inc.
-# Licensed under the Apache v2(found in the LICENSE file in the root directory).
-
-
-
 [vtgate]
-gateway_initial_tablet_timeout        = 30s
-healthcheck_timeout                   = 2s
-srv_topo_timeout                      = 1s
-grpc_keepalive_time                   = 10s
-grpc_keepalive_timeout                = 10s
-tablet_refresh_interval               = 1m
-read_write_splitting_policy           = least_rt
-read_write_splitting_ratio            = 54
-read_after_write_consistency          = GLOBAL
-read_after_write_timeout              = 66.66
-enable_buffer                         = true
-buffer_size                           = 10000
-buffer_window                         = 30s
-buffer_max_failover_duration          = 60s
-buffer_min_time_between_failovers     = 60s
-mysql_auth_server_impl                = none
-mysql_server_require_secure_transport = false
-mysql_auth_server_static_file         = foobar
-mysql_server_ssl_key                  = 
-mysql_server_ssl_cert                 = 
+gateway_initial_tablet_timeout            = 30s
+healthcheck_timeout                       = 2s
+srv_topo_timeout                          = 1s
+grpc_keepalive_time                       = 10s
+grpc_keepalive_timeout                    = 10s
+tablet_refresh_interval                   = 1m
+read_write_splitting_policy               = least_rt
+read_write_splitting_ratio                = 54
+read_after_write_consistency              = GLOBAL
+read_after_write_timeout                  = 66.66
+enable_buffer                             = true
+buffer_size                               = 10000
+buffer_window                             = 30s
+buffer_max_failover_duration              = 60s
+buffer_min_time_between_failovers         = 60s
+mysql_auth_server_impl                    = none
+mysql_server_require_secure_transport     = false
+mysql_auth_server_static_file             = 
+mysql_server_ssl_key                      = 
+mysql_server_ssl_cert                     = foobar
+enable_display_sql_execution_vttablets    = true
+enable_read_write_split_for_read_only_txn = false

--- a/go/viperutil/test/vttablet.cnf
+++ b/go/viperutil/test/vttablet.cnf
@@ -10,9 +10,20 @@ table_acl_config                    =
 queryserver_config_strict_table_acl = false
 table_acl_config_reload_interval    = 30s
 enforce_tableacl_config             = false
-# OltpReadPool
-queryserver_config_pool_size        = 30
-# OlapReadPool
-queryserver_config_stream_pool_size = 30
-# TxPool
-queryserver_config_transaction_cap  = 50
+
+# the size of database connection pool in non transaction dml
+non_transactional_dml_database_pool_size=3
+# the number of rows to be processed in one batch by default
+non_transactional_dml_default_batch_size=2000
+# the interval of batch processing in milliseconds by default
+non_transactional_dml_default_batch_interval=1
+# the interval of table GC in hours
+non_transactional_dml_table_gc_interval=24
+# the interval of job scheduler running in seconds
+non_transactional_dml_job_manager_running_interval=24
+# the interval of throttle check in milliseconds
+non_transactional_dml_throttle_check_interval=250
+# the threshold of batch size
+non_transactional_dml_batch_size_threshold=10000
+# final threshold = ratio * non_transactional_dml_batch_size_threshold / table index numbers
+non_transactional_dml_batch_size_threshold_ratio=0.5

--- a/go/viperutil/test/vttablet_test_modify.cnf
+++ b/go/viperutil/test/vttablet_test_modify.cnf
@@ -1,19 +1,29 @@
 [vttablet]
-health_check_interval               = 1s
-shard_sync_retry_delay              = 1s
-remote_operation_timeout            = 1s
-db_connect_timeout_ms               = 500
-table_acl_config_mode               = simple
-enable_logs                         = true
-enable_query_log                    = true
-table_acl_config                    = 
-queryserver_config_strict_table_acl = false
-table_acl_config_reload_interval    = 30s
-enforce_tableacl_config             = false
-# OltpReadPool
-queryserver_config_pool_size        = 30
-# OlapReadPool
-queryserver_config_stream_pool_size = 30
-# TxPool
-queryserver_config_transaction_cap  = 50
-mysql_role_probe_url_template       = http://%s:%d/v3.0/getrole
+health_check_interval                              = 1s
+shard_sync_retry_delay                             = 1s
+remote_operation_timeout                           = 1s
+db_connect_timeout_ms                              = 500
+table_acl_config_mode                              = simple
+enable_logs                                        = true
+enable_query_log                                   = true
+table_acl_config                                   = 
+queryserver_config_strict_table_acl                = false
+table_acl_config_reload_interval                   = 30s
+enforce_tableacl_config                            = false
+# the size of database connection pool in non transaction dml
+non_transactional_dml_database_pool_size           = 1
+# the number of rows to be processed in one batch by default
+non_transactional_dml_default_batch_size           = 2000
+# the interval of batch processing in milliseconds by default
+non_transactional_dml_default_batch_interval       = 1
+# the interval of table GC in hours
+non_transactional_dml_table_gc_interval            = 24
+# the interval of job scheduler running in seconds
+non_transactional_dml_job_manager_running_interval = 24
+# the interval of throttle check in milliseconds
+non_transactional_dml_throttle_check_interval      = 250
+# the threshold of batch size
+non_transactional_dml_batch_size_threshold         = 10000
+# final threshold = ratio * non_transactional_dml_batch_size_threshold / table index numbers
+non_transactional_dml_batch_size_threshold_ratio   = 0.85
+mysql_role_probe_url_template                      = http://%s:%d/v3.0/getrole

--- a/go/viperutil/viper_config.go
+++ b/go/viperutil/viper_config.go
@@ -86,9 +86,13 @@ func (v *ViperConfig) loadConfigFileAtStartup() {
 		if v.Fs == nil {
 			log.Exit("v.Fs is nil")
 		}
+<<<<<<< HEAD
 		if err := v.Fs.Set(key, value); err != nil {
 			log.Errorf("fail to set config %s=%s, err: %v", key, value, err)
 		}
+=======
+		_ = v.Fs.Set(key, value)
+>>>>>>> 0f5daf4b17 (fix: add_viper_handlers_for_some_feature_param)
 	}
 	log.Infof("finish refresh config file")
 }

--- a/go/viperutil/viper_config.go
+++ b/go/viperutil/viper_config.go
@@ -86,13 +86,9 @@ func (v *ViperConfig) loadConfigFileAtStartup() {
 		if v.Fs == nil {
 			log.Exit("v.Fs is nil")
 		}
-<<<<<<< HEAD
 		if err := v.Fs.Set(key, value); err != nil {
 			log.Errorf("fail to set config %s=%s, err: %v", key, value, err)
 		}
-=======
-		_ = v.Fs.Set(key, value)
->>>>>>> 0f5daf4b17 (fix: add_viper_handlers_for_some_feature_param)
 	}
 	log.Infof("finish refresh config file")
 }

--- a/go/viperutil/vtgate_handlers.go
+++ b/go/viperutil/vtgate_handlers.go
@@ -61,7 +61,25 @@ func RegisterReloadHandlersForVtGate(v *ViperConfig) {
 			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
 			return
 		}
-		if err := fs.Set("ddl_strategy", value); err != nil {
+		if err := fs.Set("ddl_strategy", value); err == nil {
+			_ = fs.Set("ddl_strategy", value)
+		} else {
+			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
+		}
+	})
+
+	v.ReloadHandler.AddReloadHandler("enable_display_sql_execution_vttablets", func(key string, value string, fs *pflag.FlagSet) {
+		if err := vtgate.SetDefaultEnableDisplaySQLExecutionVTTablet(value); err == nil {
+			_ = fs.Set("enable_display_sql_execution_vttablets", value)
+		} else {
+			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
+		}
+	})
+
+	v.ReloadHandler.AddReloadHandler("enable_read_write_split_for_read_only_txn", func(key string, value string, fs *pflag.FlagSet) {
+		if err := vtgate.SetDefaultReadWriteSplitForReadOnlyTxnUserInput(value); err == nil {
+			_ = fs.Set("enable_read_write_split_for_read_only_txn", value)
+		} else {
 			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
 		}
 	})

--- a/go/viperutil/vttablet_handlers.go
+++ b/go/viperutil/vttablet_handlers.go
@@ -8,6 +8,8 @@ package viperutil
 import (
 	"strconv"
 
+	"vitess.io/vitess/go/vt/vttablet/jobcontroller"
+
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/log"
@@ -27,22 +29,102 @@ func RegisterReloadHandlersForVtTablet(v *ViperConfig, tsv *tabletserver.TabletS
 	})
 
 	v.ReloadHandler.AddReloadHandler("queryserver-config-pool-size", func(key string, value string, fs *pflag.FlagSet) {
-		tsv.SetPoolSize(parseInt(key, value))
+		i, err := parseInt(key, value)
+		if err == nil {
+			tsv.SetPoolSize(i)
+		} else {
+			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
+		}
 	})
 
 	v.ReloadHandler.AddReloadHandler("queryserver-config-stream-pool-size", func(key string, value string, fs *pflag.FlagSet) {
-		tsv.SetStreamPoolSize(parseInt(key, value))
+		i, err := parseInt(key, value)
+		if err == nil {
+			tsv.SetStreamPoolSize(i)
+		} else {
+			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
+		}
 	})
 
 	v.ReloadHandler.AddReloadHandler("queryserver-config-transaction-cap", func(key string, value string, fs *pflag.FlagSet) {
-		tsv.SetTxPoolSize(parseInt(key, value))
+		i, err := parseInt(key, value)
+		if err == nil {
+			tsv.SetTxPoolSize(i)
+		} else {
+			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
+		}
+	})
+
+	v.ReloadHandler.AddReloadHandler("non_transactional_dml_database_pool_size", func(key string, value string, fs *pflag.FlagSet) {
+		if err := jobcontroller.SetDatabasePoolSize(value); err == nil {
+			_ = fs.Set("non_transactional_dml_database_pool_size", value)
+		} else {
+			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
+		}
+	})
+
+	v.ReloadHandler.AddReloadHandler("non_transactional_dml_default_batch_size", func(key string, value string, fs *pflag.FlagSet) {
+		if err := jobcontroller.SetDefaultBatchSize(value); err == nil {
+			_ = fs.Set("non_transactional_dml_default_batch_size", value)
+		} else {
+			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
+		}
+	})
+
+	v.ReloadHandler.AddReloadHandler("non_transactional_dml_default_batch_interval", func(key string, value string, fs *pflag.FlagSet) {
+		if err := jobcontroller.SetDefaultBatchInterval(value); err == nil {
+			_ = fs.Set("non_transactional_dml_default_batch_interval", value)
+		} else {
+			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
+		}
+	})
+
+	v.ReloadHandler.AddReloadHandler("non_transactional_dml_table_gc_interval", func(key string, value string, fs *pflag.FlagSet) {
+		if err := jobcontroller.SetTableGCInterval(value); err == nil {
+			_ = fs.Set("non_transactional_dml_table_gc_interval", value)
+		} else {
+			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
+		}
+	})
+
+	v.ReloadHandler.AddReloadHandler("non_transactional_dml_job_manager_running_interval", func(key string, value string, fs *pflag.FlagSet) {
+		if err := jobcontroller.SetJobManagerRunningInterval(value); err == nil {
+			_ = fs.Set("non_transactional_dml_job_manager_running_interval", value)
+		} else {
+			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
+		}
+	})
+
+	v.ReloadHandler.AddReloadHandler("non_transactional_dml_throttle_check_interval", func(key string, value string, fs *pflag.FlagSet) {
+		if err := jobcontroller.SetThrottleCheckInterval(value); err == nil {
+			_ = fs.Set("non_transactional_dml_throttle_check_interval", value)
+		} else {
+			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
+		}
+	})
+
+	v.ReloadHandler.AddReloadHandler("non_transactional_dml_batch_size_threshold", func(key string, value string, fs *pflag.FlagSet) {
+		if err := jobcontroller.SetBatchSizeThreshold(value); err == nil {
+			_ = fs.Set("non_transactional_dml_batch_size_threshold", value)
+		} else {
+			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
+		}
+	})
+
+	v.ReloadHandler.AddReloadHandler("non_transactional_dml_batch_size_threshold_ratio", func(key string, value string, fs *pflag.FlagSet) {
+		if err := jobcontroller.SetRatioOfBatchSizeThreshold(value); err == nil {
+			_ = fs.Set("non_transactional_dml_batch_size_threshold_ratio", value)
+		} else {
+			log.Errorf("fail to reload config %s=%s, err: %v", key, value, err)
+		}
 	})
 }
 
-func parseInt(key, value string) int {
+func parseInt(key, value string) (int, error) {
 	i, err := strconv.Atoi(value)
 	if err != nil {
 		log.Errorf("cannot parse %s=%s as int", key, value)
+		return 0, err
 	}
-	return i
+	return i, nil
 }

--- a/go/viperutil/vttablet_handlers_test.go
+++ b/go/viperutil/vttablet_handlers_test.go
@@ -1,3 +1,8 @@
+/*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
 package viperutil
 
 import (
@@ -35,12 +40,23 @@ table_acl_config                    =
 queryserver_config_strict_table_acl = false
 table_acl_config_reload_interval    = 30s
 enforce_tableacl_config             = false
-# OltpReadPool
-queryserver_config_pool_size        = 30
-# OlapReadPool
-queryserver_config_stream_pool_size = 30
-# TxPool
-queryserver_config_transaction_cap  = 50
+
+# the size of database connection pool in non transaction dml
+non_transactional_dml_database_pool_size=3
+# the number of rows to be processed in one batch by default
+non_transactional_dml_default_batch_size=2000
+# the interval of batch processing in milliseconds by default
+non_transactional_dml_default_batch_interval=1
+# the interval of table GC in hours
+non_transactional_dml_table_gc_interval=24
+# the interval of job scheduler running in seconds
+non_transactional_dml_job_manager_running_interval=24
+# the interval of throttle check in milliseconds
+non_transactional_dml_throttle_check_interval=250
+# the threshold of batch size
+non_transactional_dml_batch_size_threshold=10000
+# final threshold = ratio * non_transactional_dml_batch_size_threshold / table index numbers
+non_transactional_dml_batch_size_threshold_ratio=0.5
 `
 
 	// Write the content to the file
@@ -75,6 +91,18 @@ func TestRegisterReloadHandlersForVtTablet(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, time.Second, val)
 	}
+
+	{
+		val, err := fs.GetInt("non_transactional_dml_job_manager_running_interval")
+		assert.NoError(t, err)
+		assert.Equal(t, 24, val)
+	}
+
+	{
+		val, err := fs.GetFloat64("non_transactional_dml_batch_size_threshold_ratio")
+		assert.NoError(t, err)
+		assert.Equal(t, 0.5, val)
+	}
 }
 
 func TestRegisterReloadHandlersForVtTabletWithModify(t *testing.T) {
@@ -92,9 +120,10 @@ func TestRegisterReloadHandlersForVtTabletWithModify(t *testing.T) {
 	fs.StringVar(&vtTabletViperConfig.ConfigFileNotFoundHandling, "config_file_not_found_handling", IGNORE, "Behavior when a config file is not found. (Options: IGNORE, ERROR, EXIT)")
 	vtTabletViperConfig.Fs = fs
 
+	//RegisterReloadHandlersForVtTablet(vtTabletViperConfig, nil)
 	vtTabletViperConfig.LoadAndWatchConfigFile()
 
-	// expect: mysql_role_probe_url_template=http://%s:%d/v1.0/getrole
+	//expect: mysql_role_probe_url_template=http://%s:%d/v1.0/getrole
 	{
 		val, err := fs.GetString("mysql_role_probe_url_template")
 		assert.NoError(t, err)
@@ -127,6 +156,58 @@ func TestRegisterReloadHandlersForVtTabletWithModify(t *testing.T) {
 		val, err := fs.GetString("mysql_role_probe_url_template")
 		assert.NoError(t, err)
 		assert.Equal(t, "http://%s:%d/v3.0/getrole", val)
+	}
+
+	// expect: non_transactional_dml_database_pool_size = 3(default value), because non_transactional_dml_database_pool_size should >= 1
+	{
+		configFileName := "./test/vttablet_test_modify.cnf"
+		section := "vttablet"
+		key := "non_transactional_dml_database_pool_size"
+		value := "0"
+		SaveConfigTo(t, configFileName, section, key, value)
+
+		val, err := fs.GetInt("non_transactional_dml_database_pool_size")
+		assert.NoError(t, err)
+		assert.Equal(t, 3, val)
+	}
+
+	// expect: non_transactional_dml_database_pool_size = 3(default value), because non_transactional_dml_database_pool_size should >= 1
+	{
+		configFileName := "./test/vttablet_test_modify.cnf"
+		section := "vttablet"
+		key := "non_transactional_dml_database_pool_size"
+		value := "1.2345"
+		SaveConfigTo(t, configFileName, section, key, value)
+
+		val, err := fs.GetInt("non_transactional_dml_database_pool_size")
+		assert.NoError(t, err)
+		assert.Equal(t, 3, val)
+	}
+
+	// expect: non_transactional_dml_database_pool_size = 1
+	{
+		configFileName := "./test/vttablet_test_modify.cnf"
+		section := "vttablet"
+		key := "non_transactional_dml_database_pool_size"
+		value := "1"
+		SaveConfigTo(t, configFileName, section, key, value)
+
+		val, err := fs.GetInt("non_transactional_dml_database_pool_size")
+		assert.NoError(t, err)
+		assert.Equal(t, 1, val)
+	}
+
+	// expect: non_transactional_dml_batch_size_threshold_ratio = 0.85
+	{
+		configFileName := "./test/vttablet_test_modify.cnf"
+		section := "vttablet"
+		key := "non_transactional_dml_batch_size_threshold_ratio"
+		value := "0.85"
+		SaveConfigTo(t, configFileName, section, key, value)
+
+		val, err := fs.GetFloat64("non_transactional_dml_batch_size_threshold_ratio")
+		assert.NoError(t, err)
+		assert.Equal(t, 0.85, val)
 	}
 
 }

--- a/go/vt/vttablet/jobcontroller/controller.go
+++ b/go/vt/vttablet/jobcontroller/controller.go
@@ -38,8 +38,8 @@ import (
 )
 
 var (
-	databasePoolSize          = 5
-	defaultBatchSize          = 1000 //
+	databasePoolSize          = 3
+	defaultBatchSize          = 2000 //
 	defaultBatchInterval      = 1    // ms
 	tableGCInterval           = 24   // hour
 	jobManagerRunningInterval = 24   // second
@@ -53,10 +53,10 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&defaultBatchSize, "non_transactional_dml_default_batch_size", defaultBatchSize, "the number of rows to be processed in one batch by default")
 	fs.IntVar(&defaultBatchInterval, "non_transactional_dml_default_batch_interval", defaultBatchInterval, "the interval of batch processing in milliseconds by default")
 	fs.IntVar(&tableGCInterval, "non_transactional_dml_table_gc_interval", tableGCInterval, "the interval of table GC in hours")
-	fs.IntVar(&jobManagerRunningInterval, "non_transactional_dml_job_scheduler_running_interval", jobManagerRunningInterval, "the interval of job scheduler running in seconds")
+	fs.IntVar(&jobManagerRunningInterval, "non_transactional_dml_job_manager_running_interval", jobManagerRunningInterval, "the interval of job scheduler running in seconds")
 	fs.IntVar(&throttleCheckInterval, "non_transactional_dml_throttle_check_interval", throttleCheckInterval, "the interval of throttle check in milliseconds")
 	fs.IntVar(&batchSizeThreshold, "non_transactional_dml_batch_size_threshold", batchSizeThreshold, "the	threshold of batch size")
-	fs.Float64Var(&ratioOfBatchSizeThreshold, "non_transactional_dml_batch_size_threshold_ratio", ratioOfBatchSizeThreshold, "final threshold = table index numbers * ratio * non_transactional_dml_batch_size_threshold")
+	fs.Float64Var(&ratioOfBatchSizeThreshold, "non_transactional_dml_batch_size_threshold_ratio", ratioOfBatchSizeThreshold, "final threshold = ratio * non_transactional_dml_batch_size_threshold / table index numbers")
 }
 
 func init() {

--- a/go/vt/vttablet/jobcontroller/param_setting.go
+++ b/go/vt/vttablet/jobcontroller/param_setting.go
@@ -1,0 +1,118 @@
+/*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+package jobcontroller
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/pingcap/errors"
+)
+
+// SetDatabasePoolSize The constraints on this parameter are the same as in KB Addons
+func SetDatabasePoolSize(value string) error {
+	fmt.Printf("SetDatabasePoolSize: %v", value)
+	i, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	if i < 1 {
+		return errors.New("make sure that databasePoolSize >= 1")
+	}
+	databasePoolSize = i
+	return nil
+}
+
+// SetDefaultBatchSize The constraints on this parameter are the same as in KB Addons
+func SetDefaultBatchSize(value string) error {
+	i, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	if i < 1 {
+		return errors.New("make sure that defaultBatchSize >= 1")
+	}
+	defaultBatchSize = i
+	return nil
+}
+
+// SetDefaultBatchInterval The constraints on this parameter are the same as in KB Addons
+func SetDefaultBatchInterval(value string) error {
+	i, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	if i < 1 {
+		return errors.New("make sure that defaultBatchInterval >= 1")
+	}
+	defaultBatchInterval = i
+	return nil
+}
+
+// SetTableGCInterval The constraints on this parameter are the same as in KB Addons
+func SetTableGCInterval(value string) error {
+	i, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	if i < 1 {
+		return errors.New("make sure that tableGCInterval >= 1")
+	}
+	tableGCInterval = i
+	return nil
+}
+
+// SetJobManagerRunningInterval The constraints on this parameter are the same as in KB Addons
+func SetJobManagerRunningInterval(value string) error {
+	i, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	if i < 1 {
+		return errors.New("make sure that jobManagerRunningInterval >= 1")
+	}
+	jobManagerRunningInterval = i
+	return nil
+}
+
+// SetThrottleCheckInterval The constraints on this parameter are the same as in KB Addons
+func SetThrottleCheckInterval(value string) error {
+	i, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	if i < 1 {
+		return errors.New("make sure that throttleCheckInterval >= 1")
+	}
+	throttleCheckInterval = i
+	return nil
+}
+
+// SetBatchSizeThreshold The constraints on this parameter are the same as in KB Addons
+func SetBatchSizeThreshold(value string) error {
+	i, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	if i < 1 || i > 1000000 {
+		return errors.New("make sure that 1 <= batchSizeThreshold <= 1000000")
+	}
+	batchSizeThreshold = i
+	return nil
+}
+
+// SetRatioOfBatchSizeThreshold The constraints on this parameter are the same as in KB Addons
+func SetRatioOfBatchSizeThreshold(value string) error {
+	i, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return err
+	}
+	if i < 0 || i > 1 {
+		return errors.New("make sure that 0 <= ratioOfBatchSizeThreshold <= 1")
+	}
+	ratioOfBatchSizeThreshold = i
+	return nil
+}


### PR DESCRIPTION
The params of `rd only txn routing`, `dislay vttablet info when executing SQL` and `non-transactional DML` is set as DYNAMIC in KB Addons.

 As a result, when these params are modifed by user, the related pods will not restart, and new param values can work out only if we register param reload handler in Viper.
## Related Issue(s) & Descriptions

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
