### PR TITLE
feat: add the compare_objects flag in schemadiff

### DIFF
--- a/go/vt/mysqlctl/tmutils/schema.go
+++ b/go/vt/mysqlctl/tmutils/schema.go
@@ -108,22 +108,22 @@ func (s *SchemaDiffElement) Report() string {
 		if s.extraViewDatabase != s.leftDatabase {
 			extraSchema = s.right
 		}
-		buf.WriteString(fmt.Sprintf("%v has extra view %v\n:%v", s.extraViewDatabase, s.extraViewName, FindTableDefinitionFromSchema(extraSchema, s.extraViewName)))
+		buf.WriteString(fmt.Sprintf("%v has extra view %v\n:%v", s.extraViewDatabase, s.extraViewName, FindTableDefinitionFromSchema(extraSchema, s.extraViewName).Schema))
 	case ExtraTable:
 		extraSchema := s.left
 		if s.extraViewDatabase != s.leftDatabase {
 			extraSchema = s.right
 		}
-		buf.WriteString(fmt.Sprintf("%v has extra table %v\n:%v", s.extraTableDatabase, s.extraTableName, FindTableDefinitionFromSchema(extraSchema, s.extraTableName)))
+		buf.WriteString(fmt.Sprintf("%v has extra table %v\n:%v", s.extraTableDatabase, s.extraTableName, FindTableDefinitionFromSchema(extraSchema, s.extraTableName).Schema))
 	case SchemasDiffDetail:
 	case TableTypeDiff:
 		buf.WriteString(fmt.Sprintf("table %v is diff\n", s.diffTypeTableName))
-		buf.WriteString(fmt.Sprintf("%v:%v\n", s.leftDatabase, FindTableDefinitionFromSchema(s.left, s.diffTypeTableName)))
-		buf.WriteString(fmt.Sprintf("%v:%v\n", s.rightDatabase, FindTableDefinitionFromSchema(s.right, s.diffTypeTableName)))
+		buf.WriteString(fmt.Sprintf("%v:%v\n", s.leftDatabase, FindTableDefinitionFromSchema(s.left, s.diffTypeTableName).Schema))
+		buf.WriteString(fmt.Sprintf("%v:%v\n", s.rightDatabase, FindTableDefinitionFromSchema(s.right, s.diffTypeTableName).Schema))
 	case TableSchemaDiff:
 		buf.WriteString(fmt.Sprintf("table %v is diff\n", s.diffSchemaTableName))
-		buf.WriteString(fmt.Sprintf("%v:%v\n", s.leftDatabase, FindTableDefinitionFromSchema(s.left, s.diffSchemaTableName)))
-		buf.WriteString(fmt.Sprintf("%v:%v\n", s.rightDatabase, FindTableDefinitionFromSchema(s.right, s.diffSchemaTableName)))
+		buf.WriteString(fmt.Sprintf("%v:%v\n", s.leftDatabase, FindTableDefinitionFromSchema(s.left, s.diffSchemaTableName).Schema))
+		buf.WriteString(fmt.Sprintf("%v:%v\n", s.rightDatabase, FindTableDefinitionFromSchema(s.right, s.diffSchemaTableName).Schema))
 	}
 	return buf.String()
 }

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -3730,6 +3730,8 @@ func commandBranch(ctx context.Context, wr *wrangler.Wrangler, subFlags *pflag.F
 	defaultFilterRules := subFlags.String("default_filter_rules", "", "Add WHERE clause conditions to all tables.")
 	externalCluster := subFlags.String("external_cluster", "", "External cluster name")
 	workflowName := subFlags.String("workflow_name", "", "WorkflowName will be the only identification for each branch jobs")
+	outputType := subFlags.String("output_type", wrangler.OutputTypeCreateTable, "specify the type of output")
+	compareObjects := subFlags.String("compare_objects", wrangler.CompareObjectsSourceTarget, "specify objects for comparing schema diff")
 	//sourceTopoUrl := subFlags.String("source_topo_url", "", "source_topo_url will point to source topology server")
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -3753,7 +3755,7 @@ func commandBranch(ctx context.Context, wr *wrangler.Wrangler, subFlags *pflag.F
 	case vBranchWorkflowActionCleanup:
 		err = wr.CleanupBranch(ctx, *workflowName)
 	case vBranchWorkflowActionSchemeDiff:
-		err = wr.SchemaDiff(ctx, *workflowName)
+		err = wr.SchemaDiff(ctx, *workflowName, *outputType, *compareObjects)
 	default:
 		return fmt.Errorf("%v action is not support in Branch", action)
 	}

--- a/go/vt/wrangler/branch.go
+++ b/go/vt/wrangler/branch.go
@@ -931,7 +931,7 @@ func (wr *Wrangler) SchemaDiff(ctx context.Context, workflow, outputTypeFlag, co
 	case OutputTypeConflict:
 		return wr.analyseSchemaDiffAndOutputConflict(targetSchema, sourceSchema, snapshotSchema, targetDatabase, sourceDatabase, compareObjectsFlag)
 	default:
-		return fmt.Errorf("%v is incvalid output_type flag, should be one of %v, %v, %v",
+		return fmt.Errorf("%v is invalid output_type flag, should be one of %v, %v, %v",
 			outputTypeFlag, OutputTypeCreateTable, OutputTypeDDL, OutputTypeConflict)
 	}
 }
@@ -1046,7 +1046,7 @@ func (wr *Wrangler) analyseSchemaDiffAndOutputCreateTable(targetSchema, sourceSc
 		wr.Logger().Printf("schema diff between sourceDatabase and targetDatabase:\n")
 		records = tmutils.DiffSchema(sourceDatabase, sourceSchema, targetDatabase, targetSchema, &er)
 		if len(records) == 0 {
-			wr.Logger().Printf("schema is same\n")
+			wr.Logger().Printf("schemas are the same\n")
 		}
 		for _, record := range records {
 			wr.Logger().Printf("%v\n", record.Report())
@@ -1057,7 +1057,7 @@ func (wr *Wrangler) analyseSchemaDiffAndOutputCreateTable(targetSchema, sourceSc
 		wr.Logger().Printf("schema diff between targetDatabase and snapshot:\n")
 		records = tmutils.DiffSchema(targetDatabase, targetSchema, "snapshot", snapshotSchema, &er)
 		if len(records) == 0 {
-			wr.Logger().Printf("schema is same\n")
+			wr.Logger().Printf("schemas are the same\n")
 		}
 		for _, record := range records {
 			wr.Logger().Printf("%v\n", record.Report())
@@ -1068,7 +1068,7 @@ func (wr *Wrangler) analyseSchemaDiffAndOutputCreateTable(targetSchema, sourceSc
 		wr.Logger().Printf("schema diff between sourceDatabase and snapshot:\n")
 		records = tmutils.DiffSchema(sourceDatabase, sourceSchema, "snapshot", snapshotSchema, &er)
 		if len(records) == 0 {
-			wr.Logger().Printf("schema is same\n")
+			wr.Logger().Printf("schemas are the same\n")
 		}
 		for _, record := range records {
 			wr.Logger().Printf("%v\n", record.Report())


### PR DESCRIPTION
## Descriptions
Add the compare_objects flag, establishing the code framework.

Now user can use `--compare_objects` to specify the schema objects to compare, for example:
```bash
vtctlclient --server localhost:15999 Branch -- --workflow_name branch_test --compare_objects target_snapshot schemadiff
```
The option of --compare_objects flag can be one of follows:
`source_target`,  `target_source`,  `target_snapshot`,  `snapshot_target`,  `source_snapshot`,  `snapshot_source`


## Related Issue(s)
#444 

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
