### PR TITLE
Feature/support branch schemadiff output ddl and conflict

### DIFF
--- a/go/test/endtoend/cluster/vtctlclient_process.go
+++ b/go/test/endtoend/cluster/vtctlclient_process.go
@@ -184,7 +184,7 @@ func (vtctlclient *VtctlClientProcess) StopBranch(workflow string) (string, erro
 	args = append(args, "Stop")
 	return vtctlclient.ExecuteCommandWithOutput(args...)
 }
-func (vtctlclient *VtctlClientProcess) BranchPrepareMergeBack(workflow string) (string, error) {
+func (vtctlclient *VtctlClientProcess) BranchPrepareMergeBackOverride(workflow string) (string, error) {
 	args := []string{"Branch", "--"}
 	if workflow != "" {
 		args = append(args, "--workflow_name", workflow)
@@ -192,6 +192,17 @@ func (vtctlclient *VtctlClientProcess) BranchPrepareMergeBack(workflow string) (
 	args = append(args, "PrepareMergeBack")
 	return vtctlclient.ExecuteCommandWithOutput(args...)
 }
+
+func (vtctlclient *VtctlClientProcess) BranchPrepareMergeBackDiff(workflow string) (string, error) {
+	args := []string{"Branch", "--"}
+	if workflow != "" {
+		args = append(args, "--workflow_name", workflow)
+	}
+	args = append(args, "--merge_option", "diff")
+	args = append(args, "PrepareMergeBack")
+	return vtctlclient.ExecuteCommandWithOutput(args...)
+}
+
 func (vtctlclient *VtctlClientProcess) BranchStartMergeBack(workflow string) (string, error) {
 	args := []string{"Branch", "--"}
 	if workflow != "" {

--- a/go/vt/sidecardb/schema/branch/branch_jobs.sql
+++ b/go/vt/sidecardb/schema/branch/branch_jobs.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS mysql.branch_jobs
     `onddl`                          varchar(256),
     `status`                         varchar(64)      NOT NULL,
     `message`                        varchar(256),
+    `merge_timestamp`                timestamp        DEFAULT NULL,
     PRIMARY KEY (`id`),
     UNIQUE KEY(`workflow_name`)
     ) ENGINE = InnoDB;

--- a/go/vt/sidecardb/schema/branch/branch_table_rules.sql
+++ b/go/vt/sidecardb/schema/branch/branch_table_rules.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS mysql.branch_table_rules
     `create_ddl`                        text,
     `merge_ddl`                         text,
     `skip_copy_phase`                   tinyint unsigned NOT NULL DEFAULT '1',
-    `need_merge_back`                   tinyint unsigned NOT NULL DEFAULT '1',
+    `need_merge_back`                   tinyint unsigned NOT NULL DEFAULT '0',
     `merge_ddl_uuid`                    varchar(128),
     `default_filter_rules`              text,
     PRIMARY KEY (`id`),

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -3743,6 +3743,12 @@ func commandBranch(ctx context.Context, wr *wrangler.Wrangler, subFlags *pflag.F
 	action = strings.ToLower(action)
 	switch action {
 	case vBranchWorkflowActionPrepare:
+		if *include != "" {
+			return errors.New("--include is not supportted now")
+		}
+		if *excludes != "" {
+			return errors.New("--excludes is not supportted now")
+		}
 		err = wr.PrepareBranch(ctx, *workflowName, *sourceDatabase, *targetDatabase, *cells, *tabletTypes, *include, *excludes, *stopAfterCopy, *defaultFilterRules, *skipCopyPhase, *externalCluster)
 	case vBranchWorkflowActionStart:
 		err = wr.StartBranch(ctx, *workflowName)

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -3724,7 +3724,7 @@ func commandBranch(ctx context.Context, wr *wrangler.Wrangler, subFlags *pflag.F
 	skipCopyPhase := subFlags.Bool("skip_copy_phase", true, "Branch will skip copy data phase.")
 	tabletTypes := subFlags.String("tablet_types", "in_order:REPLICA,PRIMARY", "Source tablet types to replicate from (e.g. PRIMARY, REPLICA, RDONLY). Defaults to --vreplication_tablet_type parameter value for the tablet, which has the default value of in_order:REPLICA,PRIMARY. Note: SwitchTraffic overrides this default and uses in_order:RDONLY,REPLICA,PRIMARY to switch all traffic by default.")
 	include := subFlags.String("include", "", "MoveTables only. A table spec or a list of tables. Either table_specs or --all needs to be specified.")
-	excludes := subFlags.String("exclude", "", "MoveTables only. Tables to exclude (comma-separated) if --all is specified")
+	exclude := subFlags.String("exclude", "", "MoveTables only. Tables to exclude (comma-separated) if --all is specified")
 	sourceDatabase := subFlags.String("source_database", "", "MoveTables only. Source keyspace")
 	targetDatabase := subFlags.String("target_database", "", "MoveTables only. Target keyspace")
 	defaultFilterRules := subFlags.String("default_filter_rules", "", "Add WHERE clause conditions to all tables.")
@@ -3732,6 +3732,7 @@ func commandBranch(ctx context.Context, wr *wrangler.Wrangler, subFlags *pflag.F
 	workflowName := subFlags.String("workflow_name", "", "WorkflowName will be the only identification for each branch jobs")
 	outputType := subFlags.String("output_type", wrangler.OutputTypeCreateTable, "specify the type of output")
 	compareObjects := subFlags.String("compare_objects", wrangler.CompareObjectsSourceTarget, "specify objects for comparing schema diff")
+	mergeOption := subFlags.String("merge_option", wrangler.MergeOptionOverride, "specify the behavior of merging schemas, should be one of: override, diff")
 	//sourceTopoUrl := subFlags.String("source_topo_url", "", "source_topo_url will point to source topology server")
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -3744,18 +3745,18 @@ func commandBranch(ctx context.Context, wr *wrangler.Wrangler, subFlags *pflag.F
 	switch action {
 	case vBranchWorkflowActionPrepare:
 		if *include != "" {
-			return errors.New("--include is not supportted now")
+			return errors.New("--include is not supported now")
 		}
-		if *excludes != "" {
-			return errors.New("--excludes is not supportted now")
+		if *exclude != "" {
+			return errors.New("--exclude is not supported now")
 		}
-		err = wr.PrepareBranch(ctx, *workflowName, *sourceDatabase, *targetDatabase, *cells, *tabletTypes, *include, *excludes, *stopAfterCopy, *defaultFilterRules, *skipCopyPhase, *externalCluster)
+		err = wr.PrepareBranch(ctx, *workflowName, *sourceDatabase, *targetDatabase, *cells, *tabletTypes, *include, *exclude, *stopAfterCopy, *defaultFilterRules, *skipCopyPhase, *externalCluster)
 	case vBranchWorkflowActionStart:
 		err = wr.StartBranch(ctx, *workflowName)
 	case vBranchWorkflowActionStop:
 		err = wr.StopBranch(ctx, *workflowName)
 	case vBranchWorkflowActionPrepareMergeBack:
-		err = wr.PrepareMergeBackBranch(ctx, *workflowName)
+		err = wr.PrepareMergeBackBranch(ctx, *workflowName, *mergeOption)
 	case vBranchWorkflowActionStartMergeBack:
 		err = wr.StartMergeBackBranch(ctx, *workflowName)
 	case vBranchWorkflowActionCleanup:

--- a/go/vt/wrangler/branch.go
+++ b/go/vt/wrangler/branch.go
@@ -946,6 +946,8 @@ func (wr *Wrangler) storeSchemaSnapshot(ctx context.Context, workflow string, mz
 			return err
 		}
 
+		targetSchema = filterSchemaRelatedOnlineDDLArtifact(targetSchema)
+
 		schemaBlob, err := proto.Marshal(targetSchema)
 		if err != nil {
 			return err

--- a/go/vt/wrangler/branch_test.go
+++ b/go/vt/wrangler/branch_test.go
@@ -6,7 +6,10 @@ Licensed under the Apache v2(found in the LICENSE file in the root directory).
 package wrangler
 
 import (
+	"fmt"
 	"testing"
+
+	"vitess.io/vitess/go/vt/schemadiff"
 )
 
 func TestRemoveComments(t *testing.T) {
@@ -43,4 +46,163 @@ func TestRemoveComments(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSchemasConflict(t *testing.T) {
+
+	snapshotSchemaStr := `CREATE TABLE foo (
+						id INT NOT NULL,
+						col1 INT NOT NULL,
+						col2 VARCHAR(255) NOT NULL,
+						PRIMARY KEY(id),
+						KEY col1_index(col1)
+				       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
+
+	snapshotSchema, err := schemadiff.NewSchemaFromQueries([]string{snapshotSchemaStr})
+	if err != nil {
+		t.Errorf("NewSchemaFromQueries(%s) got unexpected error: %v", snapshotSchemaStr, err)
+	}
+
+	addIntCol3BasedOnSnapshot := `CREATE TABLE foo (
+								id INT NOT NULL,
+								col1 INT NOT NULL,
+								col2 VARCHAR(255) NOT NULL,
+								col3 INT NOT NULL,
+								PRIMARY KEY(id),
+                 				KEY col1_index(col1)
+						   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
+
+	addVarcharCol3BasedOnSnapshot := `CREATE TABLE foo (
+								id INT NOT NULL,
+								col1 INT NOT NULL,
+								col2 VARCHAR(255) NOT NULL,
+								col3 VARCHAR(255) NOT NULL,
+								PRIMARY KEY(id),
+                 				KEY col1_index(col1)
+						   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
+
+	dropCol1BasedOnSnapshot := `CREATE TABLE foo (
+								id INT NOT NULL,
+								col2 VARCHAR(255) NOT NULL,
+								PRIMARY KEY(id)
+						   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
+
+	dropCol2BasedOnSnapshot := `CREATE TABLE foo (
+								id INT NOT NULL,
+								col1 INT NOT NULL,
+								PRIMARY KEY(id),
+								KEY col1_index(col1)
+						   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
+
+	addIndexCol2BasedOnSnapshot := `CREATE TABLE foo (
+						id INT NOT NULL,
+						col1 INT NOT NULL,
+						col2 VARCHAR(255) NOT NULL,
+						PRIMARY KEY(id),
+						KEY col1_index(col1),
+						KEY col2_index(col2)
+				       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
+
+	dropIndexCol1BasedOnSnapshot := `CREATE TABLE foo (
+						id INT NOT NULL,
+						col1 INT NOT NULL,
+						col2 VARCHAR(255) NOT NULL,
+						PRIMARY KEY(id)
+				       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
+
+	tests := []struct {
+		name             string
+		schema1Str       string
+		schema2Str       string
+		expectedConflict bool
+	}{
+		{
+			name:             "1.schema1 add int column3, schema2 no changes, no conflict",
+			schema1Str:       addIntCol3BasedOnSnapshot,
+			schema2Str:       snapshotSchemaStr,
+			expectedConflict: false,
+		},
+		{
+			name:             "2.schema1 add int column3, schema2 add varchar col3, conflict (different col order)",
+			schema1Str:       addIntCol3BasedOnSnapshot,
+			schema2Str:       addVarcharCol3BasedOnSnapshot,
+			expectedConflict: true,
+		},
+		{
+			name:             "3.schema1 add int column3, schema2 drop col1, no conflict (both remain id, col2, col3)",
+			schema1Str:       addIntCol3BasedOnSnapshot,
+			schema2Str:       dropCol1BasedOnSnapshot,
+			expectedConflict: false,
+		},
+		{
+			name:             "4.schema1 add int column3, schema2 add index col2, no conflict",
+			schema1Str:       addIntCol3BasedOnSnapshot,
+			schema2Str:       addIndexCol2BasedOnSnapshot,
+			expectedConflict: false,
+		},
+		{
+			name:             "5.schema1 add int column3, schema2 drop index col1, no conflict",
+			schema1Str:       addIntCol3BasedOnSnapshot,
+			schema2Str:       dropIndexCol1BasedOnSnapshot,
+			expectedConflict: false,
+		},
+		{
+			name:             "6.schema1 drop col1, schema2 drop col2, no conflict (both remain id)",
+			schema1Str:       dropCol1BasedOnSnapshot,
+			schema2Str:       dropCol2BasedOnSnapshot,
+			expectedConflict: false,
+		},
+		{
+			name:             "7.schema1 drop col1, schema2 add index col2, no conflict",
+			schema1Str:       dropCol1BasedOnSnapshot,
+			schema2Str:       addIndexCol2BasedOnSnapshot,
+			expectedConflict: false,
+		},
+		{
+			name:             "8.schema1 drop col2, schema2 add index col2, conflict",
+			schema1Str:       dropCol2BasedOnSnapshot,
+			schema2Str:       addIndexCol2BasedOnSnapshot,
+			expectedConflict: true,
+		},
+		{
+			name:             "8.schema1 drop col2, schema2 drop index col1, no conflict",
+			schema1Str:       dropCol2BasedOnSnapshot,
+			schema2Str:       dropIndexCol1BasedOnSnapshot,
+			expectedConflict: false,
+		},
+		{
+			name:             "9.schema1 add index col2, schema2 drop index col1, no conflict",
+			schema1Str:       addIndexCol2BasedOnSnapshot,
+			schema2Str:       dropIndexCol1BasedOnSnapshot,
+			expectedConflict: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema1, err := schemadiff.NewSchemaFromQueries([]string{tt.schema1Str})
+			if err != nil {
+				t.Errorf("NewSchemaFromQueries(%s) got unexpected error: %v", tt.schema1Str, err)
+			}
+			schema2, err := schemadiff.NewSchemaFromQueries([]string{tt.schema2Str})
+			if err != nil {
+				t.Errorf("NewSchemaFromQueries(%s) got unexpected error: %v", tt.schema2Str, err)
+			}
+
+			conflict, message, err := SchemasConflict(schema1, schema2, snapshotSchema)
+			if err != nil {
+				t.Errorf("SchemasConflict got unexpected error: %v", err)
+			}
+
+			if conflict != tt.expectedConflict {
+				t.Errorf("SchemasConflict(%s,%s) = %v, want %v", tt.schema1Str, tt.schema2Str, conflict, tt.expectedConflict)
+			}
+
+			if tt.expectedConflict == true {
+				fmt.Printf("conflict message:%s", message)
+			}
+
+		})
+	}
+
 }


### PR DESCRIPTION
## Descriptions
### output_type flag in SchemaDiff
Support the `output_type` flag.

Now user can use `--output_type` to specify the output content, for example:

```bash
vtctlclient --server localhost:15999 Branch -- --workflow_name branch_test --compare_objects source_target --output_type ddl schemadiff
``` 
will output DDLs need to execute when transforming from source schema to target schema.

```bash
vtctlclient --server localhost:15999 Branch -- --workflow_name branch_test --compare_objects source_target --output_type conflict schemadiff
```
will output whether source schema and target schema are in conflict.

The option of `--output_type` flag can be one of follows: create_table (default), ddl, conflict.

`SchemasConflic` is developed based on the **three-way merge algorithm**. 

Unit tests on `SchemasConflic` are add in branch_test.go and it's easy to add your own interested test cases.
### merge_option flag in PrepareMergeBack
Based on these, we then support `merge_option` flag in `PrepareMergeBack`.

The option of `--merge_option` flag can be one of follows: override(default), diff.

**Override** means that source schema will be override by target schema when merging.

**Diff** means that it will check if source schema  and target schema are in conflicts. If schemas conflict, the merge process will not start.

What's more, when branch has been merged back, the `merge_timestamp` field in `branch_jobs` table will be set, and **the branch will not be merged back agin**.

## Repalated issue(s)
#444 

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
