### PR TITLE
fix: set table-acl-config-reload-interval default value to 5s

### DIFF
--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -68,7 +68,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&enforceTableACLConfig, "enforce-tableacl-config", enforceTableACLConfig, "if this flag is true, vttablet will fail to start if a valid tableacl config does not exist")
 	fs.StringVar(&tableACLConfig, "table-acl-config", tableACLConfig, "path to table access checker config file;")
 	fs.StringVar(&tableACLMode, "table-acl-config-mode", global.TableACLModeSimple, "table acl config mode (simple or mysqlbased)")
-	fs.DurationVar(&tableACLConfigReloadInterval, "table-acl-config-reload-interval", tableACLConfigReloadInterval, "Ticker to reload ACLs. Duration flag, format e.g.: 30s. Default: do not reload")
+	fs.DurationVar(&tableACLConfigReloadInterval, "table-acl-config-reload-interval", global.DefaultACLReloadInterval, "Ticker to reload ACLs. Duration flag, format e.g.: 30s. Default: do not reload")
 	fs.StringVar(&tabletPath, "tablet-path", tabletPath, "tablet alias")
 	fs.StringVar(&tabletConfig, "tablet_config", tabletConfig, "YAML file config for tablet")
 	acl.RegisterFlags(fs)

--- a/go/internal/global/global.go
+++ b/go/internal/global/global.go
@@ -5,6 +5,8 @@ Licensed under the Apache v2(found in the LICENSE file in the root directory).
 
 package global
 
+import "time"
+
 // Keyspace
 const (
 	DefaultKeyspace = "mysql"
@@ -35,9 +37,11 @@ const (
 	AuthServerNone       = "none"
 )
 
+// ACL
 const (
-	TableACLModeMysqlBased = MysqlBased
-	TableACLModeSimple     = "simple"
+	TableACLModeMysqlBased   = MysqlBased
+	TableACLModeSimple       = "simple"
+	DefaultACLReloadInterval = 5 * time.Second
 )
 
 const (


### PR DESCRIPTION
## Related Issue(s) & Descriptions
Because the table-acl-config-reload-interval value is set to 0 by default, table ACL may not update user privileges from MySQL. Therefore, it is necessary to set the table-acl-config-reload-interval value to 5 seconds.