### PR TITLE
Fix/use conn instead of mysqld in executeSchemaCommands

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -1055,32 +1060,13 @@ func deleteTopDir(dir string) (removalErr error) {
 // executeMysqlScript executes a .sql script from an io.Reader with the mysql
 // command line tool. It uses the connParams as is, not adding credentials.
 func (mysqld *Mysqld) executeMysqlScript(connParams *mysql.ConnParams, sql io.Reader) error {
-	dir, err := vtenv.VtMysqlRoot()
+	data, err := io.ReadAll(sql)
 	if err != nil {
 		return err
 	}
-	name, err := binaryPath(dir, "mysql")
-	if err != nil {
-		return err
-	}
-	cnf, err := mysqld.defaultsExtraFile(connParams)
-	if err != nil {
-		return err
-	}
-	defer os.Remove(cnf)
-	args := []string{
-		"--defaults-extra-file=" + cnf,
-		"--batch",
-	}
-	env, err := buildLdPaths()
-	if err != nil {
-		return err
-	}
-	_, _, err = execCmd(name, args, env, dir, sql)
-	if err != nil {
-		return err
-	}
-	return nil
+	sqlStr := string(data)
+	_, err = mysqld.FetchSuperQuery(context.Background(), sqlStr)
+	return err
 }
 
 // defaultsExtraFile returns the filename for a temporary config file

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -1,4 +1,9 @@
 /*
+Copyright ApeCloud, Inc.
+Licensed under the Apache v2(found in the LICENSE file in the root directory).
+*/
+
+/*
 Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +32,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"context"

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -40,15 +40,12 @@ import (
 
 var autoIncr = regexp.MustCompile(` AUTO_INCREMENT=\d+`)
 
-// executeSchemaCommands executes some SQL commands, using the mysql
-// command line tool. It uses the dba connection parameters, with credentials.
+// executeSchemaCommands executes some SQL commands,
+// In Old version, it use the mysql command line tool to execute sql.
+// But when deployed in Ape-cloud mysql cluster, which vttablet pod don't have mysqld binary, it will cause error.
+// So we use super mysql connection to execute SQL commands Now.
 func (mysqld *Mysqld) executeSchemaCommands(sql string) error {
-	params, err := mysqld.dbcfgs.DbaConnector().MysqlParams()
-	if err != nil {
-		return err
-	}
-
-	return mysqld.executeMysqlScript(params, strings.NewReader(sql))
+	return mysqld.ExecuteSuperQuery(context.Background(), sql)
 }
 
 func encodeTableName(tableName string) string {


### PR DESCRIPTION
## Related Issue(s) & Descriptions

Use connection instead of mysqld binary program in `executeSchemaCommands` function (in mysqld.go) to execute sql. Otherwise, when deploying in could, mysqld is not installed in vttablet container, and errors occur.

pr #464 apply changes above in `executeMysqlScript` function, it will casue some problem when starting clusters in e2e testcases.

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
