### PR TITLE
feat: add /debug/config endpoint for vtgate and vttablet

### DIFF
--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -448,18 +448,11 @@ func (vtg *VTGate) registerDebugEnvHandler() {
 func (vtg *VTGate) registerDebugConfigHandler() {
 	http.HandleFunc("/debug/config", func(w http.ResponseWriter, r *http.Request) {
 
-		rstMap := make(map[string]struct {
-			Value pflag.Value
-			Usage string
-			Type  string
-		})
+		rstMap := make(map[string]pflag.Value)
+
 		tabletFlagSet := servenv.GetFlagSetFor("vtgate")
 		tabletFlagSet.VisitAll(func(flag *pflag.Flag) {
-			rstMap[flag.Name] = struct {
-				Value pflag.Value
-				Usage string
-				Type  string
-			}{Value: flag.Value, Usage: flag.Usage, Type: flag.Value.Type()}
+			rstMap[flag.Name] = flag.Value
 		})
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1982,18 +1982,10 @@ func (tsv *TabletServer) registerDebugEnvHandler() {
 func (tsv *TabletServer) registerDebugConfigHandler() {
 	tsv.exporter.HandleFunc("/debug/config", func(w http.ResponseWriter, r *http.Request) {
 
-		rstMap := make(map[string]struct {
-			Value pflag.Value
-			Usage string
-			Type  string
-		})
+		rstMap := make(map[string]pflag.Value)
 		tabletFlagSet := servenv.GetFlagSetFor("vttablet")
 		tabletFlagSet.VisitAll(func(flag *pflag.Flag) {
-			rstMap[flag.Name] = struct {
-				Value pflag.Value
-				Usage string
-				Type  string
-			}{Value: flag.Value, Usage: flag.Usage, Type: flag.Value.Type()}
+			rstMap[flag.Name] = flag.Value
 		})
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")


### PR DESCRIPTION
## Descriptions

Add `/debug/config` endpoint for vtgate and vttablet. You can use this endpoint to get the realtime values of variables registerd in `pflag.FlagSet`.

For example, you can request [http://localhost:15001/debug/config](http://localhost:15001/debug/config) to get variable values of vtgate, and get a json object like:

```
{
    "allowed_tablet_types": null,
    "buffer_drain_concurrency": 1,
    "buffer_implementation": "keyspace_events",
    "buffer_keyspace_shards": "",
    "buffer_max_failover_duration": 20000000000,
    ...
}
```

you can also request [http://localhost:15100/debug/config](http://localhost:15100/debug/config) to get variable values of vttablet which alias is `100`.

## Related Issue
#461 

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required
