### PR TITLE
fix: fix bugs in schemaChanged

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -155,7 +155,13 @@ func (me *Engine) schemaChanged(tables map[string]*schema.Table, created, altere
 	}
 
 	for _, name := range append(created, altered...) {
-		t := tables[name]
+		t, ok := tables[name]
+		if !ok {
+			// tables in 'created' or 'altered' list may not in the 'tables' list, because
+			// populatePrimaryKeys(ctx context.Context, conn *connpool.DBConn, tables map[string]*Table) called in
+			// func (se *Engine) reload(ctx context.Context, includeStats bool) will delete tables which have no primary keys defined.
+			continue
+		}
 		if t.Type != schema.Message {
 			continue
 		}


### PR DESCRIPTION
## Related Issue(s) & Descriptions

fix #468 


The `func (me *Engine) schemaChanged(tables map[string]*schema.Table, created, altered, dropped []string)` assumes that tables in both the `created` and `altered` arrays exist in the `tables` map, leading to a null pointer error in the subsequent code. 
```
for _, name := range append(created, altered...) {
		t := tables[name]
		if t.Type != schema.Message {
			continue
		}
                ...
}

```

However, in reality, if tables in the `created` and `altered` arrays are not explicitly defined with primary keys, they will not exist in the tables map (as determined in the `func (se *Engine) populatePrimaryKeys(ctx context.Context, conn *connpool.DBConn, tables map[string]*Table) error`). 

Therefore, we should add an additional check to verify whether the tables exist in the tables map.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required
