### PR TITLE
Add mysqlprobe & autoprobe

### DIFF
--- a/examples/wesql-server/conf/vtgate.cnf
+++ b/examples/wesql-server/conf/vtgate.cnf
@@ -1,4 +1,5 @@
 [vtgate]
+v=100
 gateway_initial_tablet_timeout=30s
 healthcheck_timeout=2s
 srv_topo_timeout=1s

--- a/examples/wesql-server/conf/vttablet.cnf
+++ b/examples/wesql-server/conf/vttablet.cnf
@@ -1,4 +1,5 @@
 [vttablet]
+v=100
 health_check_interval=1s
 shard_sync_retry_delay=1s
 remote_operation_timeout=1s

--- a/go/vt/vttablet/tabletserver/role/auto_probe.go
+++ b/go/vt/vttablet/tabletserver/role/auto_probe.go
@@ -1,0 +1,67 @@
+package role
+
+import (
+	"context"
+	"fmt"
+	"vitess.io/vitess/go/vt/log"
+
+	"github.com/spf13/pflag"
+	"vitess.io/vitess/go/vt/servenv"
+)
+
+type probeFuncEntry struct {
+	name string
+	fn   ProbeFunc
+}
+
+var (
+	autoRoleProbeImplementationList = []string{"http", "wesql", "mysql"}
+	currentProbeFuncEntryList       = make([]probeFuncEntry, 0)
+)
+
+func init() {
+	servenv.OnParseFor("vttablet", registerAutoProbeFlags)
+}
+
+func registerAutoProbeFlags(fs *pflag.FlagSet) {
+	fs.StringSliceVar(&autoRoleProbeImplementationList, "auto_role_probe_implementation_list", autoRoleProbeImplementationList, "List of probe implementations to determine the role")
+}
+
+func reloadAutoProbeFuncList() {
+	log.Infof("Reloading auto probe function list: %s", autoRoleProbeImplementationList)
+	for _, probeFuncName := range autoRoleProbeImplementationList {
+		probeFunc, ok := ProbeFuncMap[probeFuncName]
+		if !ok {
+			log.Errorf("Probe function '%s' not found", probeFuncName)
+			continue
+		}
+		currentProbeFuncEntryList = append(currentProbeFuncEntryList, probeFuncEntry{name: probeFuncName, fn: probeFunc})
+	}
+}
+
+func autoProbe(ctx context.Context) (string, error) {
+	if len(autoRoleProbeImplementationList) == 0 {
+		return "", fmt.Errorf("no probe implementations specified")
+	}
+	if len(currentProbeFuncEntryList) == 0 {
+		// Reload the probe function list if it is empty, this may happen if the probe function all failed at least once
+		reloadAutoProbeFuncList()
+	}
+
+	var lastErr error
+	// use probeFunc in currentProbeFuncEntryList to probe the role, if failed, remove it from the list
+	for len(currentProbeFuncEntryList) > 0 {
+		probeFuncEntry := currentProbeFuncEntryList[0]
+		probeFuncName := probeFuncEntry.name
+		probeFunc := probeFuncEntry.fn
+		role, err := probeFunc(ctx)
+		if err != nil {
+			log.Errorf("Probe function '%s' failed: %v, remove it", probeFuncName, err)
+			currentProbeFuncEntryList = currentProbeFuncEntryList[1:]
+			lastErr = err
+			continue
+		}
+		return role, nil
+	}
+	return UNKNOWN, fmt.Errorf("all probe functions failed, last error: %v", lastErr)
+}

--- a/go/vt/vttablet/tabletserver/role/auto_probe.go
+++ b/go/vt/vttablet/tabletserver/role/auto_probe.go
@@ -14,6 +14,10 @@ type probeFuncEntry struct {
 	fn   ProbeFunc
 }
 
+func (p *probeFuncEntry) String() string {
+	return p.name
+}
+
 var (
 	autoRoleProbeImplementationList = []string{"http", "wesql", "mysql"}
 	currentProbeFuncEntryList       = make([]probeFuncEntry, 0)
@@ -28,6 +32,7 @@ func registerAutoProbeFlags(fs *pflag.FlagSet) {
 }
 
 func reloadAutoProbeFuncList() {
+	currentProbeFuncEntryList = make([]probeFuncEntry, 0)
 	log.Infof("Reloading auto probe function list: %s", autoRoleProbeImplementationList)
 	for _, probeFuncName := range autoRoleProbeImplementationList {
 		probeFunc, ok := ProbeFuncMap[probeFuncName]
@@ -47,6 +52,8 @@ func autoProbe(ctx context.Context) (string, error) {
 		// Reload the probe function list if it is empty, this may happen if the probe function all failed at least once
 		reloadAutoProbeFuncList()
 	}
+
+	log.Debugf("Current probe function list: %v", currentProbeFuncEntryList)
 
 	var lastErr error
 	// use probeFunc in currentProbeFuncEntryList to probe the role, if failed, remove it from the list

--- a/go/vt/vttablet/tabletserver/role/auto_probe_test.go
+++ b/go/vt/vttablet/tabletserver/role/auto_probe_test.go
@@ -1,0 +1,52 @@
+package role
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_probeFuncEntry_String(t *testing.T) {
+	type fields struct {
+		name string
+		fn   ProbeFunc
+	}
+	tests := []struct {
+		fields fields
+		want   string
+	}{
+		{
+			fields: fields{
+				name: "test",
+				fn:   nil,
+			},
+			want: "test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			p := &probeFuncEntry{
+				name: tt.fields.name,
+				fn:   tt.fields.fn,
+			}
+			if got := p.String(); got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_reloadAutoProbeFuncList(t *testing.T) {
+	autoRoleProbeImplementationList = []string{"http", "wesql", "mysql"}
+	currentProbeFuncEntryList = make([]probeFuncEntry, 0)
+	ProbeFuncMap = make(map[string]ProbeFunc)
+	ProbeFuncMap["http"] = httpProbe
+	ProbeFuncMap["wesql"] = wesqlProbe
+	ProbeFuncMap["mysql"] = mysqlProbe
+	reloadAutoProbeFuncList()
+
+	assert.Equal(t, 3, len(currentProbeFuncEntryList))
+
+	autoRoleProbeImplementationList = []string{"http", "wesql", "mysql", "unknown"}
+	reloadAutoProbeFuncList()
+	assert.Equal(t, 3, len(currentProbeFuncEntryList))
+}

--- a/go/vt/vttablet/tabletserver/role/http_probe.go
+++ b/go/vt/vttablet/tabletserver/role/http_probe.go
@@ -46,17 +46,17 @@ func httpProbe(ctx context.Context) (string, error) {
 
 	kvResp, err := doHttpProbe(ctx, http.MethodGet, getRoleUrl, nil)
 	if err != nil {
-		return "", fmt.Errorf("try to probe mysql role, but error happened: %v", err)
+		return UNKNOWN, fmt.Errorf("try to probe mysql role, but error happened: %v", err)
 	}
 	role, ok := kvResp["role"]
 	if !ok {
-		return "", fmt.Errorf("unable to get mysql role from probe response, response content: %v", kvResp)
+		return UNKNOWN, fmt.Errorf("unable to get mysql role from probe response, response content: %v", kvResp)
 	}
 
 	// Safely assert the type of role to string.
 	roleStr, ok := role.(string)
 	if !ok {
-		return "", fmt.Errorf("role value is not a string, role:%v", role)
+		return UNKNOWN, fmt.Errorf("role value is not a string, role:%v", role)
 	}
 	return roleStr, nil
 }

--- a/go/vt/vttablet/tabletserver/role/listener.go
+++ b/go/vt/vttablet/tabletserver/role/listener.go
@@ -182,6 +182,7 @@ func (collector *Listener) reconcileLeadership(ctx context.Context) {
 		log.Errorf("failed to probe mysql role, error:%v\n", err)
 		return
 	}
+	log.Debugf("mysqlRoleProbeImplementation: %s, probed role: %s\n", mysqlRoleProbeImplementation, role)
 
 	tabletType := transitionRoleType(role)
 

--- a/go/vt/vttablet/tabletserver/role/listener.go
+++ b/go/vt/vttablet/tabletserver/role/listener.go
@@ -28,7 +28,7 @@ var (
 	mysqlRoleProbeEnable   = true
 	mysqlRoleProbeInterval = 1 * time.Second
 	mysqlRoleProbeTimeout  = 1 * time.Second
-	// http, wesql
+	// http, wesql, mysql
 	mysqlRoleProbeImplementation = "wesql"
 )
 
@@ -42,6 +42,7 @@ const (
 	LEARNER   = "Learner"
 	CANDIDATE = "Candidate"
 	LOGGER    = "Logger"
+	UNKNOWN   = "unknown"
 )
 
 func transitionRoleType(role string) topodatapb.TabletType {
@@ -98,6 +99,9 @@ func NewListener(changeTypeFunc func(ctx context.Context, lastUpdate time.Time, 
 	case "wesql":
 		weSqlDbConfigs = dbcfgs
 		probeFunc = wesqlProbe
+	case "mysql":
+		mysqlDbConfigs = dbcfgs
+		probeFunc = mysqlProbe
 	}
 	l := &Listener{
 		isOpen:         0,

--- a/go/vt/vttablet/tabletserver/role/mysql_probe.go
+++ b/go/vt/vttablet/tabletserver/role/mysql_probe.go
@@ -1,0 +1,149 @@
+package role
+
+import (
+	"context"
+	"fmt"
+	"vitess.io/vitess/go/mysql"
+
+	"vitess.io/vitess/go/vt/dbconfigs"
+)
+
+var (
+	mysqlDbConfigs *dbconfigs.DBConfigs
+)
+
+// mysqlProbe determines the role of a MySQL instance.
+// Possible roles: "PRIMARY", "FOLLOWER", ", "UNKNOWN".
+func mysqlProbe(ctx context.Context) (string, error) {
+	connector := mysqlDbConfigs.AllPrivsConnector()
+	conn, err := connector.Connect(ctx)
+	if err != nil {
+		return UNKNOWN, fmt.Errorf("failed to connect to database: %v", err)
+	}
+	defer conn.Close()
+
+	checkGroupReplication := false
+	// If enabled, check for Group Replication role
+	if checkGroupReplication {
+		role, err := detectGroupReplicationRole(conn)
+		if err != nil {
+			return UNKNOWN, err
+		}
+		if role != "" {
+			return role, nil
+		}
+	}
+
+	// Check if the instance is a replica (slave)
+	isReplica, err := checkIfReplica(conn)
+	if err != nil {
+		return UNKNOWN, err
+	}
+	if isReplica {
+		readOnly, err := isReadOnly(conn)
+		if err != nil {
+			return UNKNOWN, err
+		}
+		if readOnly {
+			// Map to RDONLY
+			return FOLLOWER, nil
+		}
+		// Map to REPLICA
+		return FOLLOWER, nil
+	}
+
+	// Check if the instance is a master or standalone
+	readOnly, err := isReadOnly(conn)
+	if err != nil {
+		return UNKNOWN, err
+	}
+
+	if !readOnly {
+		// The instance is a MASTER or standalone
+		return PRIMARY, nil
+	}
+
+	// If none of the above, return UNKNOWN
+	return UNKNOWN, nil
+}
+
+// checkIfReplica checks if the instance is configured as a replica.
+func checkIfReplica(conn *mysql.Conn) (bool, error) {
+	qr, err := conn.ExecuteFetch("SHOW SLAVE STATUS", 1, true)
+	if err != nil {
+		return false, fmt.Errorf("failed to execute SHOW SLAVE STATUS: %v", err)
+	}
+	return len(qr.Rows) > 0, nil
+}
+
+// isReadOnly checks if the instance is in read-only mode.
+func isReadOnly(conn *mysql.Conn) (bool, error) {
+	readOnly, err := getGlobalVariable(conn, "read_only")
+	if err != nil {
+		return false, err
+	}
+
+	superReadOnly, err := getGlobalVariable(conn, "super_read_only")
+	if err != nil {
+		return false, err
+	}
+
+	return readOnly == "ON" || superReadOnly == "ON", nil
+}
+
+// detectGroupReplicationRole checks the Group Replication role of the instance.
+func detectGroupReplicationRole(conn *mysql.Conn) (string, error) {
+	// Check if Group Replication is running
+	groupName, err := getGlobalVariable(conn, "group_replication_group_name")
+	if err != nil || groupName == "" {
+		// Not using Group Replication
+		return "", nil
+	}
+
+	// Check if Single-Primary Mode is enabled
+	singlePrimaryMode, err := getGlobalVariable(conn, "group_replication_single_primary_mode")
+	if err != nil {
+		return "", fmt.Errorf("failed to get group_replication_single_primary_mode: %v", err)
+	}
+
+	// Get the member role and state
+	query := "SELECT MEMBER_ROLE, MEMBER_STATE FROM performance_schema.replication_group_members WHERE MEMBER_ID = @@server_uuid"
+	qr, err := conn.ExecuteFetch(query, 1, true)
+	if err != nil || len(qr.Rows) == 0 {
+		return "", fmt.Errorf("failed to get group replication member info: %v", err)
+	}
+	memberRole := qr.Rows[0][0].ToString()
+	memberState := qr.Rows[0][1].ToString()
+
+	if memberState != "ONLINE" {
+		return "", nil
+	}
+
+	if singlePrimaryMode == "ON" {
+		if memberRole == "PRIMARY" {
+			return "MASTER", nil
+		} else if memberRole == "SECONDARY" {
+			return "REPLICA", nil
+		}
+	} else {
+		// Multi-Primary Mode is not supported; return UNKNOWN
+		return "", nil
+	}
+
+	return "", nil
+}
+
+// getGlobalVariable fetches the value of a MySQL global system variable.
+func getGlobalVariable(conn *mysql.Conn, variable string) (string, error) {
+	query := fmt.Sprintf("SHOW GLOBAL VARIABLES LIKE '%s'", variable)
+
+	qr, err := conn.ExecuteFetch(query, 1, true)
+	if err != nil {
+		return "", fmt.Errorf("failed to get variable %s: %v", variable, err)
+	}
+	if len(qr.Rows) == 0 {
+		return "", nil // Variable not found
+	}
+	value := qr.Rows[0][1].ToString()
+	return value, nil
+}

--- a/go/vt/vttablet/tabletserver/role/mysql_probe.go
+++ b/go/vt/vttablet/tabletserver/role/mysql_probe.go
@@ -3,10 +3,24 @@ package role
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/pflag"
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/servenv"
 
 	"vitess.io/vitess/go/vt/dbconfigs"
 )
+
+var (
+	mysqlProbeEnableMgr = false
+)
+
+func init() {
+	servenv.OnParseFor("vttablet", registerMySqlProbeFlags)
+}
+
+func registerMySqlProbeFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&mysqlProbeEnableMgr, "mysql_probe_enable_mgr", mysqlProbeEnableMgr, "enable mysql probe. default is false")
+}
 
 var (
 	mysqlDbConfigs *dbconfigs.DBConfigs
@@ -22,9 +36,8 @@ func mysqlProbe(ctx context.Context) (string, error) {
 	}
 	defer conn.Close()
 
-	checkGroupReplication := false
 	// If enabled, check for Group Replication role
-	if checkGroupReplication {
+	if mysqlProbeEnableMgr {
 		role, err := detectGroupReplicationRole(conn)
 		if err != nil {
 			return UNKNOWN, err

--- a/go/vt/vttablet/tabletserver/role/wesql_probe.go
+++ b/go/vt/vttablet/tabletserver/role/wesql_probe.go
@@ -17,20 +17,20 @@ func wesqlProbe(ctx context.Context) (string, error) {
 	connector := weSqlDbConfigs.AllPrivsConnector()
 	conn, err := connector.Connect(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to connect to database: %v", err)
+		return UNKNOWN, fmt.Errorf("failed to connect to database: %v", err)
 	}
 	defer conn.Close()
 
 	qr, err := conn.ExecuteFetch(weSqlProbeStatement, 1, true)
 	if err != nil {
-		return "", fmt.Errorf("failed to execute weSqlProbeStatement: %v", err)
+		return UNKNOWN, fmt.Errorf("failed to execute weSqlProbeStatement: %v", err)
 	}
 	if len(qr.Rows) != 1 {
 		log.Errorf("unexpected number of rows returned by weSqlProbeStatement: %d\n", len(qr.Rows))
-		return "", nil
+		return UNKNOWN, nil
 	}
 	if qr.Named() == nil || qr.Named().Row() == nil {
-		return "", fmt.Errorf("unexpected result from weSqlProbeStatement: %v", qr)
+		return UNKNOWN, fmt.Errorf("unexpected result from weSqlProbeStatement: %v", qr)
 	}
 	role, err := qr.Named().Row().ToString("role")
 	return role, err


### PR DESCRIPTION
## Related Issue(s) & Descriptions

1. Add mysqlProbe, which allows `wescale` to consult  vanilla mysql about the current role
2. Add autoProbe, which is able to automatically detect the current usable `probeFunc`

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] Tests were added or are not required
-   [x] Documentation was added or is not required
