### PR TITLE
Improve filter rules reloading

### DIFF
--- a/go/vt/vttablet/customrule/config.go
+++ b/go/vt/vttablet/customrule/config.go
@@ -14,7 +14,7 @@ var (
 	DatabaseCustomRuleDbName            = sidecardb.SidecarDBName
 	DatabaseCustomRuleTableName         = "wescale_plugin"
 	DatabaseCustomRuleReloadInterval    = 60 * time.Second
-	DatabaseCustomRuleNotifierDelayTime = 100 * time.Millisecond
+	DatabaseCustomRuleNotifierDelayTime = 100 * time.Millisecond // time to wait for primary inserting filters and the filters are synced to replicas
 )
 
 func registerFlags(fs *pflag.FlagSet) {

--- a/go/vt/vttablet/customrule/databasecustomrule/databasecustomrule.go
+++ b/go/vt/vttablet/customrule/databasecustomrule/databasecustomrule.go
@@ -45,6 +45,11 @@ func newDatabaseCustomRule(qsc tabletserver.Controller) (*databaseCustomRule, er
 
 func (cr *databaseCustomRule) start() {
 	go func() {
+		// reload rules that already in the database once start
+		if err := cr.reloadRulesFromDatabase(); err != nil {
+			log.Warningf("Background watch of database custom rule failed: %v", err)
+		}
+
 		intervalTicker := time.NewTicker(customrule.DatabaseCustomRuleReloadInterval)
 		defer intervalTicker.Stop()
 

--- a/go/vt/vttablet/customrule/databasecustomrule/databasecustomrule.go
+++ b/go/vt/vttablet/customrule/databasecustomrule/databasecustomrule.go
@@ -59,7 +59,7 @@ func (cr *databaseCustomRule) start() {
 		for {
 			select {
 			case <-intervalTicker.C:
-			case <-customrule.Watch():
+				//case <-customrule.Watch():
 			}
 
 			if err := cr.reloadRulesFromDatabase(); err != nil {

--- a/go/vt/vttablet/customrule/notifier.go
+++ b/go/vt/vttablet/customrule/notifier.go
@@ -13,5 +13,4 @@ func Watch() <-chan struct{} {
 	return customRuleChanged
 }
 
-var WaitForFilterLoad func(name string) error
-var WaitForFilterDelete func(name string) error
+var WaitForFilter func(name string, shouldExists bool) error

--- a/go/vt/vttablet/customrule/notifier.go
+++ b/go/vt/vttablet/customrule/notifier.go
@@ -12,3 +12,6 @@ func NotifyReload() {
 func Watch() <-chan struct{} {
 	return customRuleChanged
 }
+
+var WaitForFilterLoad func(name string) error
+var WaitForFilterDelete func(name string) error


### PR DESCRIPTION
## Related Issue(s) & Descriptions
#596 

1. Load the existing rules from the system table as soon as the filter component starts.
2. Change the filter's create, drop, and alter processes from asynchronous to synchronous.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required
